### PR TITLE
Docs - add usage with Xcode (macOS only)

### DIFF
--- a/docs/simpleble/usage.rst
+++ b/docs/simpleble/usage.rst
@@ -185,7 +185,7 @@ Navigate to your target.
 Under the **General** tab, **Frameworks and Libraries** section, add the following frameworks:
   - Foundation
   - CoreBluetooth
-Under the **Build Settings** tab, Search Paths section, update the following settings:
+Under the **Build Settings** tab, **Search Paths** section, update the following settings:
   - Header Search Paths (add <path-to-simpleble>/include)
   - Library Search Paths (add <path-to-simpleble>/lib)
 

--- a/docs/simpleble/usage.rst
+++ b/docs/simpleble/usage.rst
@@ -177,6 +177,19 @@ the following CMake options available:
   - ``LIBFMT_LOCAL_PATH``: The local path to use for fmtlib. *(Default: None)*
 
 
+Usage with Xcode **(macOS only)** 
+=================================
+
+Create Xcode C++ project.
+Navigate to your target.
+Under the **General** tab, **Frameworks and Libraries** section, add the following frameworks:
+  - Foundation
+  - CoreBluetooth
+Under the **Build Settings** tab, Search Paths section, update the following settings:
+  - Header Search Paths (add <path-to-simpleble>/include)
+  - Library Search Paths (add <path-to-simpleble>/lib)
+
+
 Build Examples
 ==============
 


### PR DESCRIPTION
Adds usage with Xcode (macOS only) documentation. Without it a developer on macOS following the usage instructions and then moving on to the tutorial will encounter linker errors.