### PR TITLE
Fix non-existent DBus1 path in exported CMake target

### DIFF
--- a/simplebluez/CMakeLists.txt
+++ b/simplebluez/CMakeLists.txt
@@ -99,9 +99,7 @@ target_include_directories(simplebluez PRIVATE ${SIMPLEBLUEZ_INCLUDE})
 target_include_directories(simplebluez INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../simpledbus/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    $<INSTALL_INTERFACE:${DBus1_INCLUDE_DIR}>
-    $<INSTALL_INTERFACE:${DBus1_ARCH_INCLUDE_DIR}>)
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 append_sanitize_options("${SIMPLEBLUEZ_SANITIZE}")
 
@@ -118,14 +116,24 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/simplebluez.pc.in
 
 install(
     TARGETS simplebluez
-    EXPORT simplebluez-config
+    EXPORT simplebluez-targets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(
-    EXPORT simplebluez-config
+    EXPORT simplebluez-targets
     NAMESPACE simplebluez::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/simplebluez)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/simplebluez-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/simplebluez-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/simplebluez)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/simplebluez-config.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/simplebluez)
 
 install(

--- a/simplebluez/cmake/simplebluez-config.cmake.in
+++ b/simplebluez/cmake/simplebluez-config.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(DBus1)
+
+include("${CMAKE_CURRENT_LIST_DIR}/simplebluez-targets.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/simpledbus/CMakeLists.txt
+++ b/simpledbus/CMakeLists.txt
@@ -63,9 +63,7 @@ target_link_libraries(simpledbus PRIVATE $<BUILD_INTERFACE:fmt::fmt-header-only>
 target_include_directories(simpledbus PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(simpledbus INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    $<INSTALL_INTERFACE:${DBus1_INCLUDE_DIR}>
-    $<INSTALL_INTERFACE:${DBus1_ARCH_INCLUDE_DIR}>)
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 append_sanitize_options("${SIMPLEDBUS_SANITIZE}")
 
@@ -82,14 +80,24 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/simpledbus.pc.in
 
 install(
     TARGETS simpledbus
-    EXPORT simpledbus-config
+    EXPORT simpledbus-targets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(
-    EXPORT simpledbus-config
+    EXPORT simpledbus-targets
     NAMESPACE simpledbus::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/simpledbus)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/simpledbus-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/simpledbus-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/simpledbus)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/simpledbus-config.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/simpledbus)
 
 install(

--- a/simpledbus/cmake/simpledbus-config.cmake.in
+++ b/simpledbus/cmake/simpledbus-config.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(DBus1)
+
+include("${CMAKE_CURRENT_LIST_DIR}/simpledbus-targets.cmake")
+check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
This commit fixes the issue of SimpleBluez or SimpleDBus failing CMake configuration due to non-existent path in exported target. The issue occurs if DBus1 package files have moved since the installation of these libraries.

SimpleBluez and SimpleDBus should not make assumptions about the location or presence of files provided by DBus1 package. Instead, finding the DBus1 dependency should be done during package configuration by find_dependency() macro.