### PR TITLE
Improve const correctness of the C++ API

### DIFF
--- a/simpleble/include/simpleble/Adapter.h
+++ b/simpleble/include/simpleble/Adapter.h
@@ -23,21 +23,21 @@ class SIMPLEBLE_EXPORT Adapter {
     bool initialized() const;
     void* underlying() const;
 
-    std::string identifier();
-    BluetoothAddress address();
+    std::string identifier() const;
+    BluetoothAddress address() const;
 
     void scan_start();
     void scan_stop();
     void scan_for(int timeout_ms);
-    bool scan_is_active();
-    std::vector<Peripheral> scan_get_results();
+    bool scan_is_active() const;
+    std::vector<Peripheral> scan_get_results() const;
 
     void set_callback_on_scan_start(std::function<void()> on_scan_start);
     void set_callback_on_scan_stop(std::function<void()> on_scan_stop);
     void set_callback_on_scan_updated(std::function<void(Peripheral)> on_scan_updated);
     void set_callback_on_scan_found(std::function<void(Peripheral)> on_scan_found);
 
-    std::vector<Peripheral> get_paired_peripherals();
+    std::vector<Peripheral> get_paired_peripherals() const;
 
     static bool bluetooth_enabled();
 
@@ -47,6 +47,8 @@ class SIMPLEBLE_EXPORT Adapter {
     static std::vector<Adapter> get_adapters();
 
   protected:
+    AdapterBase &internal();
+    const AdapterBase &internal() const;
     std::shared_ptr<AdapterBase> internal_;
 };
 

--- a/simpleble/include/simpleble/Characteristic.h
+++ b/simpleble/include/simpleble/Characteristic.h
@@ -17,17 +17,19 @@ class SIMPLEBLE_EXPORT Characteristic {
     Characteristic() = default;
     virtual ~Characteristic() = default;
 
-    BluetoothUUID uuid();
-    std::vector<Descriptor> descriptors();
-    std::vector<std::string> capabilities();
+    BluetoothUUID uuid() const;
+    std::vector<Descriptor> descriptors() const;
+    std::vector<std::string> capabilities() const;
 
-    bool can_read();
-    bool can_write_request();
-    bool can_write_command();
-    bool can_notify();
-    bool can_indicate();
+    bool can_read() const;
+    bool can_write_request() const;
+    bool can_write_command() const;
+    bool can_notify() const;
+    bool can_indicate() const;
 
   protected:
+    CharacteristicBase &internal();
+    const CharacteristicBase &internal() const;
     std::shared_ptr<CharacteristicBase> internal_;
 };
 

--- a/simpleble/include/simpleble/Descriptor.h
+++ b/simpleble/include/simpleble/Descriptor.h
@@ -16,9 +16,10 @@ class SIMPLEBLE_EXPORT Descriptor {
     Descriptor() = default;
     virtual ~Descriptor() = default;
 
-    BluetoothUUID uuid();
+    BluetoothUUID uuid() const;
 
   protected:
+    const DescriptorBase &internal() const;
     std::shared_ptr<DescriptorBase> internal_;
 };
 

--- a/simpleble/include/simpleble/Peripheral.h
+++ b/simpleble/include/simpleble/Peripheral.h
@@ -25,10 +25,10 @@ class SIMPLEBLE_EXPORT Peripheral {
     bool initialized() const;
     void* underlying() const;
 
-    std::string identifier();
-    BluetoothAddress address();
-    BluetoothAddressType address_type();
-    int16_t rssi();
+    std::string identifier() const;
+    BluetoothAddress address() const;
+    BluetoothAddressType address_type() const;
+    int16_t rssi() const;
 
     /**
      * @brief Provides the advertised transmit power in dBm.
@@ -36,8 +36,8 @@ class SIMPLEBLE_EXPORT Peripheral {
      * @note If the field has not been advertised by the peripheral,
      *       the returned value will be -32768.
      */
-    int16_t tx_power();
-    uint16_t mtu();
+    int16_t tx_power() const;
+    uint16_t mtu() const;
 
     void connect();
     void disconnect();
@@ -71,6 +71,8 @@ class SIMPLEBLE_EXPORT Peripheral {
     void set_callback_on_disconnected(std::function<void()> on_disconnected);
 
   protected:
+    PeripheralBase &internal();
+    const PeripheralBase &internal() const;
     std::shared_ptr<PeripheralBase> internal_;
 };
 

--- a/simpleble/include/simpleble/Service.h
+++ b/simpleble/include/simpleble/Service.h
@@ -18,11 +18,13 @@ class SIMPLEBLE_EXPORT Service {
     Service() = default;
     virtual ~Service() = default;
 
-    BluetoothUUID uuid();
-    ByteArray data();
-    std::vector<Characteristic> characteristics();
+    BluetoothUUID uuid() const;
+    ByteArray data() const;
+    std::vector<Characteristic> characteristics() const;
 
   protected:
+    ServiceBase &internal();
+    const ServiceBase &internal() const;
     std::shared_ptr<ServiceBase> internal_;
 };
 

--- a/simpleble/src/backends/common/CharacteristicBase.cpp
+++ b/simpleble/src/backends/common/CharacteristicBase.cpp
@@ -16,12 +16,12 @@ CharacteristicBase::CharacteristicBase(const BluetoothUUID& uuid, std::vector<De
       can_notify_(can_notify),
       can_indicate_(can_indicate) {}
 
-BluetoothUUID CharacteristicBase::uuid() { return uuid_; }
+BluetoothUUID CharacteristicBase::uuid() const { return uuid_; }
 
-std::vector<Descriptor> CharacteristicBase::descriptors() { return descriptors_; }
+std::vector<Descriptor> CharacteristicBase::descriptors() const { return descriptors_; }
 
-bool CharacteristicBase::can_read() { return can_read_; }
-bool CharacteristicBase::can_write_request() { return can_write_request_; }
-bool CharacteristicBase::can_write_command() { return can_write_command_; }
-bool CharacteristicBase::can_notify() { return can_notify_; }
-bool CharacteristicBase::can_indicate() { return can_indicate_; }
+bool CharacteristicBase::can_read() const { return can_read_; }
+bool CharacteristicBase::can_write_request() const { return can_write_request_; }
+bool CharacteristicBase::can_write_command() const { return can_write_command_; }
+bool CharacteristicBase::can_notify() const { return can_notify_; }
+bool CharacteristicBase::can_indicate() const { return can_indicate_; }

--- a/simpleble/src/backends/common/CharacteristicBase.h
+++ b/simpleble/src/backends/common/CharacteristicBase.h
@@ -12,14 +12,14 @@ class CharacteristicBase {
                        bool can_write_request, bool can_write_command, bool can_notify, bool can_indicate);
     virtual ~CharacteristicBase() = default;
 
-    BluetoothUUID uuid();
-    std::vector<Descriptor> descriptors();
+    BluetoothUUID uuid() const;
+    std::vector<Descriptor> descriptors() const;
 
-    bool can_read();
-    bool can_write_request();
-    bool can_write_command();
-    bool can_notify();
-    bool can_indicate();
+    bool can_read() const;
+    bool can_write_request() const;
+    bool can_write_command() const;
+    bool can_notify() const;
+    bool can_indicate() const;
 
   protected:
     BluetoothUUID uuid_;

--- a/simpleble/src/backends/common/DescriptorBase.cpp
+++ b/simpleble/src/backends/common/DescriptorBase.cpp
@@ -7,4 +7,4 @@ using namespace SimpleBLE;
 
 DescriptorBase::DescriptorBase(const BluetoothUUID& uuid) : uuid_(uuid) {}
 
-BluetoothUUID DescriptorBase::uuid() { return uuid_; }
+BluetoothUUID DescriptorBase::uuid() const { return uuid_; }

--- a/simpleble/src/backends/common/DescriptorBase.h
+++ b/simpleble/src/backends/common/DescriptorBase.h
@@ -10,7 +10,7 @@ class DescriptorBase {
     DescriptorBase(const BluetoothUUID& uuid);
     virtual ~DescriptorBase() = default;
 
-    BluetoothUUID uuid();
+    BluetoothUUID uuid() const;
 
   protected:
     BluetoothUUID uuid_;

--- a/simpleble/src/backends/common/ServiceBase.cpp
+++ b/simpleble/src/backends/common/ServiceBase.cpp
@@ -12,8 +12,8 @@ ServiceBase::ServiceBase(const BluetoothUUID& uuid, const ByteArray& data) : uui
 ServiceBase::ServiceBase(const BluetoothUUID& uuid, std::vector<Characteristic>& characteristics)
     : uuid_(uuid), characteristics_(characteristics) {}
 
-BluetoothUUID ServiceBase::uuid() { return uuid_; }
+BluetoothUUID ServiceBase::uuid() const { return uuid_; }
 
-ByteArray ServiceBase::data() { return data_; }
+ByteArray ServiceBase::data() const { return data_; }
 
-std::vector<Characteristic> ServiceBase::characteristics() { return characteristics_; }
+std::vector<Characteristic> ServiceBase::characteristics() const { return characteristics_; }

--- a/simpleble/src/backends/common/ServiceBase.h
+++ b/simpleble/src/backends/common/ServiceBase.h
@@ -13,9 +13,9 @@ class ServiceBase {
     ServiceBase(const BluetoothUUID& uuid, std::vector<Characteristic>& characteristics);
     virtual ~ServiceBase() = default;
 
-    BluetoothUUID uuid();
-    ByteArray data();
-    std::vector<Characteristic> characteristics();
+    BluetoothUUID uuid() const;
+    ByteArray data() const;
+    std::vector<Characteristic> characteristics() const;
 
   protected:
     BluetoothUUID uuid_;

--- a/simpleble/src/backends/linux/AdapterBase.cpp
+++ b/simpleble/src/backends/linux/AdapterBase.cpp
@@ -35,9 +35,9 @@ AdapterBase::~AdapterBase() { adapter_->clear_on_device_updated(); }
 
 void* AdapterBase::underlying() const { return adapter_.get(); }
 
-std::string AdapterBase::identifier() { return adapter_->identifier(); }
+std::string AdapterBase::identifier() const { return adapter_->identifier(); }
 
-BluetoothAddress AdapterBase::address() { return adapter_->address(); }
+BluetoothAddress AdapterBase::address() const { return adapter_->address(); }
 
 void AdapterBase::scan_start() {
     seen_peripherals_.clear();
@@ -91,9 +91,9 @@ void AdapterBase::scan_for(int timeout_ms) {
     scan_stop();
 }
 
-bool AdapterBase::scan_is_active() { return is_scanning_ && adapter_->discovering(); }
+bool AdapterBase::scan_is_active() const { return is_scanning_ && adapter_->discovering(); }
 
-std::vector<Peripheral> AdapterBase::scan_get_results() {
+std::vector<Peripheral> AdapterBase::scan_get_results() const {
     std::vector<Peripheral> peripherals;
     for (auto& [address, peripheral] : this->seen_peripherals_) {
         PeripheralBuilder peripheral_builder(peripheral);
@@ -102,7 +102,7 @@ std::vector<Peripheral> AdapterBase::scan_get_results() {
     return peripherals;
 }
 
-std::vector<Peripheral> AdapterBase::get_paired_peripherals() {
+std::vector<Peripheral> AdapterBase::get_paired_peripherals() const {
     std::vector<Peripheral> peripherals;
 
     auto paired_list = adapter_->device_paired_get();

--- a/simpleble/src/backends/linux/AdapterBase.h
+++ b/simpleble/src/backends/linux/AdapterBase.h
@@ -24,21 +24,21 @@ class AdapterBase {
 
     void* underlying() const;
 
-    std::string identifier();
-    BluetoothAddress address();
+    std::string identifier() const;
+    BluetoothAddress address() const;
 
     void scan_start();
     void scan_stop();
     void scan_for(int timeout_ms);
-    bool scan_is_active();
-    std::vector<Peripheral> scan_get_results();
+    bool scan_is_active() const;
+    std::vector<Peripheral> scan_get_results() const;
 
     void set_callback_on_scan_start(std::function<void()> on_scan_start);
     void set_callback_on_scan_stop(std::function<void()> on_scan_stop);
     void set_callback_on_scan_updated(std::function<void(Peripheral)> on_scan_updated);
     void set_callback_on_scan_found(std::function<void(Peripheral)> on_scan_found);
 
-    std::vector<Peripheral> get_paired_peripherals();
+    std::vector<Peripheral> get_paired_peripherals() const;
 
     static bool bluetooth_enabled();
     static std::vector<std::shared_ptr<AdapterBase>> get_adapters();

--- a/simpleble/src/backends/linux/PeripheralBase.cpp
+++ b/simpleble/src/backends/linux/PeripheralBase.cpp
@@ -34,11 +34,11 @@ PeripheralBase::~PeripheralBase() {
 
 void* PeripheralBase::underlying() const { return device_.get(); }
 
-std::string PeripheralBase::identifier() { return device_->name(); }
+std::string PeripheralBase::identifier() const { return device_->name(); }
 
-BluetoothAddress PeripheralBase::address() { return device_->address(); }
+BluetoothAddress PeripheralBase::address() const { return device_->address(); }
 
-BluetoothAddressType PeripheralBase::address_type() {
+BluetoothAddressType PeripheralBase::address_type() const {
     std::string address_type = device_->address_type();
 
     if (address_type == "public") {
@@ -50,11 +50,11 @@ BluetoothAddressType PeripheralBase::address_type() {
     }
 }
 
-int16_t PeripheralBase::rssi() { return device_->rssi(); }
+int16_t PeripheralBase::rssi() const { return device_->rssi(); }
 
-int16_t PeripheralBase::tx_power() { return device_->tx_power(); }
+int16_t PeripheralBase::tx_power() const { return device_->tx_power(); }
 
-uint16_t PeripheralBase::mtu() {
+uint16_t PeripheralBase::mtu() const {
     if (!is_connected()) return 0;
 
     for (auto bluez_service : device_->services()) {
@@ -107,15 +107,15 @@ void PeripheralBase::disconnect() {
     }
 }
 
-bool PeripheralBase::is_connected() {
+bool PeripheralBase::is_connected() const {
     // NOTE: For Bluez, a device being connected means that it's both
     // connected and services have been resolved.
     return device_->connected() && device_->services_resolved();
 }
 
-bool PeripheralBase::is_connectable() { return device_->name() != ""; }
+bool PeripheralBase::is_connectable() const { return device_->name() != ""; }
 
-bool PeripheralBase::is_paired() { return device_->paired(); }
+bool PeripheralBase::is_paired() const { return device_->paired(); }
 
 void PeripheralBase::unpair() {
     if (device_->paired()) {
@@ -123,7 +123,7 @@ void PeripheralBase::unpair() {
     }
 }
 
-std::vector<Service> PeripheralBase::services() {
+std::vector<Service> PeripheralBase::services() const {
     bool is_battery_service_available = false;
 
     std::vector<Service> service_list;
@@ -169,7 +169,7 @@ std::vector<Service> PeripheralBase::services() {
     return service_list;
 }
 
-std::vector<Service> PeripheralBase::advertised_services() {
+std::vector<Service> PeripheralBase::advertised_services() const {
     std::vector<Service> service_list;
     for (auto& service_uuid : device_->uuids()) {
         service_list.push_back(ServiceBuilder(service_uuid));
@@ -178,7 +178,7 @@ std::vector<Service> PeripheralBase::advertised_services() {
     return service_list;
 }
 
-std::map<uint16_t, ByteArray> PeripheralBase::manufacturer_data() {
+std::map<uint16_t, ByteArray> PeripheralBase::manufacturer_data() const {
     std::map<uint16_t, ByteArray> manufacturer_data;
     for (auto& [manufacturer_id, value_array] : device_->manufacturer_data()) {
         manufacturer_data[manufacturer_id] = ByteArray((const char*)value_array.data(), value_array.size());

--- a/simpleble/src/backends/linux/PeripheralBase.h
+++ b/simpleble/src/backends/linux/PeripheralBase.h
@@ -23,23 +23,23 @@ class PeripheralBase {
 
     void* underlying() const;
 
-    std::string identifier();
-    BluetoothAddress address();
-    BluetoothAddressType address_type();
-    int16_t rssi();
-    int16_t tx_power();
-    uint16_t mtu();
+    std::string identifier() const;
+    BluetoothAddress address() const;
+    BluetoothAddressType address_type() const;
+    int16_t rssi() const;
+    int16_t tx_power() const;
+    uint16_t mtu() const;
 
     void connect();
     void disconnect();
-    bool is_connected();
-    bool is_connectable();
-    bool is_paired();
+    bool is_connected() const;
+    bool is_connectable() const;
+    bool is_paired() const;
     void unpair();
 
-    std::vector<Service> services();
-    std::vector<Service> advertised_services();
-    std::map<uint16_t, ByteArray> manufacturer_data();
+    std::vector<Service> services() const;
+    std::vector<Service> advertised_services() const;
+    std::map<uint16_t, ByteArray> manufacturer_data() const;
 
     // clang-format off
     ByteArray read(BluetoothUUID const& service, BluetoothUUID const& characteristic);

--- a/simpleble/src/backends/macos/AdapterBase.h
+++ b/simpleble/src/backends/macos/AdapterBase.h
@@ -27,21 +27,21 @@ class AdapterBase {
 
     void* underlying() const;
 
-    std::string identifier();
-    BluetoothAddress address();
+    std::string identifier() const;
+    BluetoothAddress address() const;
 
     void scan_start();
     void scan_stop();
     void scan_for(int timeout_ms);
-    bool scan_is_active();
-    std::vector<Peripheral> scan_get_results();
+    bool scan_is_active() const;
+    std::vector<Peripheral> scan_get_results() const;
 
     void set_callback_on_scan_start(std::function<void()> on_scan_start);
     void set_callback_on_scan_stop(std::function<void()> on_scan_stop);
     void set_callback_on_scan_updated(std::function<void(Peripheral)> on_scan_updated);
     void set_callback_on_scan_found(std::function<void(Peripheral)> on_scan_found);
 
-    std::vector<Peripheral> get_paired_peripherals();
+    std::vector<Peripheral> get_paired_peripherals() const;
 
     static bool bluetooth_enabled();
     static std::vector<std::shared_ptr<AdapterBase> > get_adapters();

--- a/simpleble/src/backends/macos/AdapterBase.mm
+++ b/simpleble/src/backends/macos/AdapterBase.mm
@@ -52,11 +52,11 @@ void* AdapterBase::underlying() const {
     return [internal underlying];
 }
 
-std::string AdapterBase::identifier() {
+std::string AdapterBase::identifier() const {
     return fmt::format("Default Adapter [{}]", this->address());
 }
 
-BluetoothAddress AdapterBase::address() {
+BluetoothAddress AdapterBase::address() const {
     AdapterBaseMacOS* internal = (__bridge AdapterBaseMacOS*)opaque_internal_;
 
     return [[internal address] UTF8String];
@@ -84,12 +84,12 @@ void AdapterBase::scan_for(int timeout_ms) {
     this->scan_stop();
 }
 
-bool AdapterBase::scan_is_active() {
+bool AdapterBase::scan_is_active() const {
     AdapterBaseMacOS* internal = (__bridge AdapterBaseMacOS*)opaque_internal_;
     return [internal scanIsActive];
 }
 
-std::vector<Peripheral> AdapterBase::scan_get_results() {
+std::vector<Peripheral> AdapterBase::scan_get_results() const {
     std::vector<Peripheral> peripherals;
     for (auto& [opaque_peripheral, base_peripheral] : this->seen_peripherals_) {
         PeripheralBuilder peripheral_builder(base_peripheral);
@@ -127,7 +127,7 @@ void AdapterBase::set_callback_on_scan_found(std::function<void(Peripheral)> on_
     }
 }
 
-std::vector<Peripheral> AdapterBase::get_paired_peripherals() { return {}; }
+std::vector<Peripheral> AdapterBase::get_paired_peripherals() const { return {}; }
 
 // Delegate methods passed for AdapterBaseMacOS
 

--- a/simpleble/src/backends/macos/PeripheralBase.h
+++ b/simpleble/src/backends/macos/PeripheralBase.h
@@ -19,23 +19,23 @@ class PeripheralBase {
 
     void* underlying() const;
 
-    std::string identifier();
-    BluetoothAddress address();
-    BluetoothAddressType address_type();
-    int16_t tx_power();
-    int16_t rssi();
-    uint16_t mtu();
+    std::string identifier() const;
+    BluetoothAddress address() const;
+    BluetoothAddressType address_type() const;
+    int16_t tx_power() const;
+    int16_t rssi() const;
+    uint16_t mtu() const;
 
     void connect();
     void disconnect();
-    bool is_connected();
-    bool is_connectable();
-    bool is_paired();
+    bool is_connected() const;
+    bool is_connectable() const;
+    bool is_paired() const;
     void unpair();
 
-    std::vector<Service> services();
-    std::vector<Service> advertised_services();
-    std::map<uint16_t, ByteArray> manufacturer_data();
+    std::vector<Service> services() const;
+    std::vector<Service> advertised_services() const;
+    std::map<uint16_t, ByteArray> manufacturer_data() const;
 
     // clang-format off
     ByteArray read(BluetoothUUID const& service, BluetoothUUID const& characteristic);

--- a/simpleble/src/backends/macos/PeripheralBase.mm
+++ b/simpleble/src/backends/macos/PeripheralBase.mm
@@ -39,25 +39,25 @@ void* PeripheralBase::underlying() const {
     return [internal underlying];
 }
 
-std::string PeripheralBase::identifier() {
+std::string PeripheralBase::identifier() const {
     PeripheralBaseMacOS* internal = (__bridge PeripheralBaseMacOS*)opaque_internal_;
     return std::string([[internal identifier] UTF8String]);
 }
 
-BluetoothAddress PeripheralBase::address() {
+BluetoothAddress PeripheralBase::address() const {
     PeripheralBaseMacOS* internal = (__bridge PeripheralBaseMacOS*)opaque_internal_;
     return std::string([[internal address] UTF8String]);
 }
 
-BluetoothAddressType PeripheralBase::address_type() {
+BluetoothAddressType PeripheralBase::address_type() const {
     return BluetoothAddressType::UNSPECIFIED;
 }
 
-int16_t PeripheralBase::rssi() { return rssi_; }
+int16_t PeripheralBase::rssi() const { return rssi_; }
 
-int16_t PeripheralBase::tx_power() { return tx_power_; }
+int16_t PeripheralBase::tx_power() const { return tx_power_; }
 
-uint16_t PeripheralBase::mtu() {
+uint16_t PeripheralBase::mtu() const {
     PeripheralBaseMacOS* internal = (__bridge PeripheralBaseMacOS*)opaque_internal_;
     return [internal mtu];
 }
@@ -90,23 +90,23 @@ void PeripheralBase::disconnect() {
     manual_disconnect_triggered_ = false;
 }
 
-bool PeripheralBase::is_connected() {
+bool PeripheralBase::is_connected() const {
     PeripheralBaseMacOS* internal = (__bridge PeripheralBaseMacOS*)opaque_internal_;
     return [internal isConnected];
 }
 
-bool PeripheralBase::is_connectable() { return is_connectable_; }
+bool PeripheralBase::is_connectable() const { return is_connectable_; }
 
-bool PeripheralBase::is_paired() { throw Exception::OperationNotSupported(); }
+bool PeripheralBase::is_paired() const { throw Exception::OperationNotSupported(); }
 
 void PeripheralBase::unpair() { throw Exception::OperationNotSupported(); }
 
-std::vector<Service> PeripheralBase::services() {
+std::vector<Service> PeripheralBase::services() const {
     PeripheralBaseMacOS* internal = (__bridge PeripheralBaseMacOS*)opaque_internal_;
     return [internal getServices];
 }
 
-std::vector<Service> PeripheralBase::advertised_services() {
+std::vector<Service> PeripheralBase::advertised_services() const {
     std::vector<Service> service_list;
     for (auto& [service_uuid, data] : service_data_) {
         service_list.push_back(ServiceBuilder(service_uuid, data));
@@ -115,7 +115,7 @@ std::vector<Service> PeripheralBase::advertised_services() {
     return service_list;
 }
 
-std::map<uint16_t, ByteArray> PeripheralBase::manufacturer_data() { return manufacturer_data_; }
+std::map<uint16_t, ByteArray> PeripheralBase::manufacturer_data() const { return manufacturer_data_; }
 
 ByteArray PeripheralBase::read(BluetoothUUID const& service, BluetoothUUID const& characteristic) {
     PeripheralBaseMacOS* internal = (__bridge PeripheralBaseMacOS*)opaque_internal_;

--- a/simpleble/src/backends/plain/PeripheralBase.h
+++ b/simpleble/src/backends/plain/PeripheralBase.h
@@ -20,23 +20,23 @@ class PeripheralBase {
 
     void* underlying() const;
 
-    std::string identifier();
-    BluetoothAddress address();
-    BluetoothAddressType address_type();
-    int16_t rssi();
-    int16_t tx_power();
-    uint16_t mtu();
+    std::string identifier() const;
+    BluetoothAddress address() const;
+    BluetoothAddressType address_type() const;
+    int16_t rssi() const;
+    int16_t tx_power() const;
+    uint16_t mtu() const;
 
     void connect();
     void disconnect();
-    bool is_connected();
-    bool is_connectable();
-    bool is_paired();
+    bool is_connected() const;
+    bool is_connectable() const;
+    bool is_paired() const;
     void unpair();
 
-    std::vector<Service> services();
-    std::vector<Service> advertised_services();
-    std::map<uint16_t, ByteArray> manufacturer_data();
+    std::vector<Service> services() const;
+    std::vector<Service> advertised_services() const;
+    std::map<uint16_t, ByteArray> manufacturer_data() const;
 
     // clang-format off
     ByteArray read(BluetoothUUID const& service, BluetoothUUID const& characteristic);

--- a/simpleble/src/backends/windows/AdapterBase.cpp
+++ b/simpleble/src/backends/windows/AdapterBase.cpp
@@ -183,9 +183,9 @@ std::vector<std::shared_ptr<AdapterBase>> AdapterBase::get_adapters() {
 
 void* AdapterBase::underlying() const { return reinterpret_cast<void*>(const_cast<BluetoothAdapter*>(&adapter_)); }
 
-std::string AdapterBase::identifier() { return identifier_; }
+std::string AdapterBase::identifier() const { return identifier_; }
 
-BluetoothAddress AdapterBase::address() { return _mac_address_to_str(adapter_.BluetoothAddress()); }
+BluetoothAddress AdapterBase::address() const { return _mac_address_to_str(adapter_.BluetoothAddress()); }
 
 void AdapterBase::scan_start() {
     this->seen_peripherals_.clear();
@@ -215,9 +215,9 @@ void AdapterBase::scan_for(int timeout_ms) {
     scan_stop();
 }
 
-bool AdapterBase::scan_is_active() { return scan_is_active_; }
+bool AdapterBase::scan_is_active() const { return scan_is_active_; }
 
-std::vector<Peripheral> AdapterBase::scan_get_results() {
+std::vector<Peripheral> AdapterBase::scan_get_results() const {
     std::vector<Peripheral> peripherals;
     for (auto& [address, base_peripheral] : this->seen_peripherals_) {
         PeripheralBuilder peripheral_builder(base_peripheral);
@@ -227,7 +227,7 @@ std::vector<Peripheral> AdapterBase::scan_get_results() {
     return peripherals;
 }
 
-std::vector<Peripheral> AdapterBase::get_paired_peripherals() { return {}; }
+std::vector<Peripheral> AdapterBase::get_paired_peripherals() const { return {}; }
 
 void AdapterBase::set_callback_on_scan_start(std::function<void()> on_scan_start) {
     if (on_scan_start) {

--- a/simpleble/src/backends/windows/AdapterBase.h
+++ b/simpleble/src/backends/windows/AdapterBase.h
@@ -33,21 +33,21 @@ class AdapterBase {
 
     void* underlying() const;
 
-    std::string identifier();
-    BluetoothAddress address();
+    std::string identifier() const;
+    BluetoothAddress address() const;
 
     void scan_start();
     void scan_stop();
     void scan_for(int timeout_ms);
-    bool scan_is_active();
-    std::vector<Peripheral> scan_get_results();
+    bool scan_is_active() const;
+    std::vector<Peripheral> scan_get_results() const;
 
     void set_callback_on_scan_start(std::function<void()> on_scan_start);
     void set_callback_on_scan_stop(std::function<void()> on_scan_stop);
     void set_callback_on_scan_updated(std::function<void(Peripheral)> on_scan_updated);
     void set_callback_on_scan_found(std::function<void(Peripheral)> on_scan_found);
 
-    std::vector<Peripheral> get_paired_peripherals();
+    std::vector<Peripheral> get_paired_peripherals() const;
 
     static bool bluetooth_enabled();
     static std::vector<std::shared_ptr<AdapterBase>> get_adapters();

--- a/simpleble/src/backends/windows/PeripheralBase.cpp
+++ b/simpleble/src/backends/windows/PeripheralBase.cpp
@@ -40,17 +40,17 @@ PeripheralBase::~PeripheralBase() {
 
 void* PeripheralBase::underlying() const { return reinterpret_cast<void*>(const_cast<BluetoothLEDevice*>(&device_)); }
 
-SimpleBLE::BluetoothAddressType PeripheralBase::address_type() { return address_type_; }
+SimpleBLE::BluetoothAddressType PeripheralBase::address_type() const { return address_type_; }
 
-std::string PeripheralBase::identifier() { return identifier_; }
+std::string PeripheralBase::identifier() const { return identifier_; }
 
-BluetoothAddress PeripheralBase::address() { return address_; }
+BluetoothAddress PeripheralBase::address() const { return address_; }
 
-int16_t PeripheralBase::rssi() { return rssi_; }
+int16_t PeripheralBase::rssi() const { return rssi_; }
 
-int16_t PeripheralBase::tx_power() { return tx_power_; }
+int16_t PeripheralBase::tx_power() const { return tx_power_; }
 
-uint16_t PeripheralBase::mtu() {
+uint16_t PeripheralBase::mtu() const {
     if (!is_connected()) return 0;
 
     // The value provided by the MaxPduSize includes an extra 3 bytes from the GATT header
@@ -114,13 +114,13 @@ void PeripheralBase::disconnect() {
     }
 }
 
-bool PeripheralBase::is_connected() {
+bool PeripheralBase::is_connected() const {
     return device_ != nullptr && device_.ConnectionStatus() == BluetoothConnectionStatus::Connected;
 }
 
-bool PeripheralBase::is_connectable() { return connectable_; }
+bool PeripheralBase::is_connectable() const { return connectable_; }
 
-bool PeripheralBase::is_paired() { throw Exception::OperationNotSupported(); }
+bool PeripheralBase::is_paired() const { throw Exception::OperationNotSupported(); }
 
 void PeripheralBase::unpair() { throw Exception::OperationNotSupported(); }
 
@@ -153,7 +153,7 @@ std::vector<Service> PeripheralBase::services() {
     return service_list;
 }
 
-std::vector<Service> PeripheralBase::advertised_services() {
+std::vector<Service> PeripheralBase::advertised_services() const {
     std::vector<Service> service_list;
     for (auto& [service_uuid, data] : service_data_) {
         service_list.push_back(ServiceBuilder(service_uuid, data));
@@ -162,7 +162,7 @@ std::vector<Service> PeripheralBase::advertised_services() {
     return service_list;
 }
 
-std::map<uint16_t, ByteArray> PeripheralBase::manufacturer_data() { return manufacturer_data_; }
+std::map<uint16_t, ByteArray> PeripheralBase::manufacturer_data() const { return manufacturer_data_; }
 
 ByteArray PeripheralBase::read(BluetoothUUID const& service, BluetoothUUID const& characteristic) {
     GattCharacteristic gatt_characteristic = _fetch_characteristic(service, characteristic).obj;

--- a/simpleble/src/backends/windows/PeripheralBase.h
+++ b/simpleble/src/backends/windows/PeripheralBase.h
@@ -44,23 +44,23 @@ class PeripheralBase {
 
     void* underlying() const;
 
-    std::string identifier();
-    BluetoothAddress address();
-    SimpleBLE::BluetoothAddressType address_type();
-    int16_t rssi();
-    int16_t tx_power();
-    uint16_t mtu();
+    std::string identifier() const;
+    BluetoothAddress address() const;
+    SimpleBLE::BluetoothAddressType address_type() const;
+    int16_t rssi() const;
+    int16_t tx_power() const;
+    uint16_t mtu() const;
 
     void connect();
     void disconnect();
-    bool is_connected();
-    bool is_connectable();
-    bool is_paired();
+    bool is_connected() const;
+    bool is_connectable() const;
+    bool is_paired() const;
     void unpair();
 
-    std::vector<Service> services();
-    std::vector<Service> advertised_services();
-    std::map<uint16_t, ByteArray> manufacturer_data();
+    std::vector<Service> services() const;
+    std::vector<Service> advertised_services() const;
+    std::map<uint16_t, ByteArray> manufacturer_data() const;
 
     // clang-format off
     ByteArray read(BluetoothUUID const& service, BluetoothUUID const& characteristic);

--- a/simpleble/src/frontends/base/Adapter.cpp
+++ b/simpleble/src/frontends/base/Adapter.cpp
@@ -25,19 +25,19 @@ bool Adapter::initialized() const { return internal_ != nullptr; }
 void* Adapter::underlying() const {
     if (!initialized()) throw Exception::NotInitialized();
 
-    return internal_->underlying();
+    return internal().underlying();
 }
 
-std::string Adapter::identifier() {
+std::string Adapter::identifier() const {
     if (!initialized()) throw Exception::NotInitialized();
 
-    return internal_->identifier();
+    return internal().identifier();
 }
 
-BluetoothAddress Adapter::address() {
+BluetoothAddress Adapter::address() const {
     if (!initialized()) throw Exception::NotInitialized();
 
-    return internal_->address();
+    return internal().address();
 }
 
 void Adapter::scan_start() {
@@ -46,7 +46,7 @@ void Adapter::scan_start() {
         SIMPLEBLE_LOG_WARN(fmt::format("Bluetooth is not enabled."));
         return;
     }
-    internal_->scan_start();
+    internal().scan_start();
 }
 
 void Adapter::scan_stop() {
@@ -55,7 +55,7 @@ void Adapter::scan_stop() {
         SIMPLEBLE_LOG_WARN(fmt::format("Bluetooth is not enabled."));
         return;
     }
-    internal_->scan_stop();
+    internal().scan_stop();
 }
 
 void Adapter::scan_for(int timeout_ms) {
@@ -64,47 +64,55 @@ void Adapter::scan_for(int timeout_ms) {
         SIMPLEBLE_LOG_WARN(fmt::format("Bluetooth is not enabled."));
         return;
     }
-    internal_->scan_for(timeout_ms);
+    internal().scan_for(timeout_ms);
 }
 
-bool Adapter::scan_is_active() {
+bool Adapter::scan_is_active() const {
     if (!initialized()) throw Exception::NotInitialized();
 
-    return internal_->scan_is_active();
+    return internal().scan_is_active();
 }
 
-std::vector<Peripheral> Adapter::scan_get_results() {
+std::vector<Peripheral> Adapter::scan_get_results() const {
     if (!initialized()) throw Exception::NotInitialized();
 
-    return internal_->scan_get_results();
+    return internal().scan_get_results();
 }
 
-std::vector<Peripheral> Adapter::get_paired_peripherals() {
+std::vector<Peripheral> Adapter::get_paired_peripherals() const {
     if (!initialized()) throw Exception::NotInitialized();
 
-    return internal_->get_paired_peripherals();
+    return internal().get_paired_peripherals();
 }
 
 void Adapter::set_callback_on_scan_start(std::function<void()> on_scan_start) {
     if (!initialized()) throw Exception::NotInitialized();
 
-    internal_->set_callback_on_scan_start(std::move(on_scan_start));
+    internal().set_callback_on_scan_start(std::move(on_scan_start));
 }
 
 void Adapter::set_callback_on_scan_stop(std::function<void()> on_scan_stop) {
     if (!initialized()) throw Exception::NotInitialized();
 
-    internal_->set_callback_on_scan_stop(std::move(on_scan_stop));
+    internal().set_callback_on_scan_stop(std::move(on_scan_stop));
 }
 
 void Adapter::set_callback_on_scan_updated(std::function<void(Peripheral)> on_scan_updated) {
     if (!initialized()) throw Exception::NotInitialized();
 
-    internal_->set_callback_on_scan_updated(std::move(on_scan_updated));
+    internal().set_callback_on_scan_updated(std::move(on_scan_updated));
 }
 
 void Adapter::set_callback_on_scan_found(std::function<void(Peripheral)> on_scan_found) {
     if (!initialized()) throw Exception::NotInitialized();
 
-    internal_->set_callback_on_scan_found(std::move(on_scan_found));
+    internal().set_callback_on_scan_found(std::move(on_scan_found));
+}
+
+AdapterBase &Adapter::internal() {
+    return *internal_;
+}
+
+const AdapterBase &Adapter::internal() const {
+    return *internal_;
 }

--- a/simpleble/src/frontends/base/Characteristic.cpp
+++ b/simpleble/src/frontends/base/Characteristic.cpp
@@ -5,11 +5,11 @@
 
 using namespace SimpleBLE;
 
-BluetoothUUID Characteristic::uuid() { return internal_->uuid(); }
+BluetoothUUID Characteristic::uuid() const { return internal().uuid(); }
 
-std::vector<Descriptor> Characteristic::descriptors() { return internal_->descriptors(); }
+std::vector<Descriptor> Characteristic::descriptors() const { return internal().descriptors(); }
 
-std::vector<std::string> Characteristic::capabilities() {
+std::vector<std::string> Characteristic::capabilities() const {
     std::vector<std::string> capabilities;
 
     if (can_read()) {
@@ -35,8 +35,11 @@ std::vector<std::string> Characteristic::capabilities() {
     return capabilities;
 }
 
-bool Characteristic::can_read() { return internal_->can_read(); }
-bool Characteristic::can_write_request() { return internal_->can_write_request(); }
-bool Characteristic::can_write_command() { return internal_->can_write_command(); }
-bool Characteristic::can_notify() { return internal_->can_notify(); }
-bool Characteristic::can_indicate() { return internal_->can_indicate(); }
+bool Characteristic::can_read() const { return internal().can_read(); }
+bool Characteristic::can_write_request() const { return internal().can_write_request(); }
+bool Characteristic::can_write_command() const { return internal().can_write_command(); }
+bool Characteristic::can_notify() const { return internal().can_notify(); }
+bool Characteristic::can_indicate() const { return internal().can_indicate(); }
+
+CharacteristicBase &Characteristic::internal() { return *internal_; }
+const CharacteristicBase &Characteristic::internal() const { return *internal_; }

--- a/simpleble/src/frontends/base/Descriptor.cpp
+++ b/simpleble/src/frontends/base/Descriptor.cpp
@@ -5,4 +5,6 @@
 
 using namespace SimpleBLE;
 
-BluetoothUUID Descriptor::uuid() { return internal_->uuid(); }
+BluetoothUUID Descriptor::uuid() const { return internal().uuid(); }
+
+const DescriptorBase &Descriptor::internal() const { return *internal_; }

--- a/simpleble/src/frontends/base/Peripheral.cpp
+++ b/simpleble/src/frontends/base/Peripheral.cpp
@@ -10,104 +10,104 @@ bool Peripheral::initialized() const { return internal_ != nullptr; }
 void* Peripheral::underlying() const {
     if (!initialized()) throw Exception::NotInitialized();
 
-    return internal_->underlying();
+    return internal().underlying();
 }
 
-std::string Peripheral::identifier() {
+std::string Peripheral::identifier() const {
     if (!initialized()) throw Exception::NotInitialized();
 
-    return internal_->identifier();
+    return internal().identifier();
 }
 
-SimpleBLE::BluetoothAddress Peripheral::address() {
+SimpleBLE::BluetoothAddress Peripheral::address() const {
     if (!initialized()) throw Exception::NotInitialized();
 
-    return internal_->address();
+    return internal().address();
 }
 
-SimpleBLE::BluetoothAddressType Peripheral::address_type() {
+SimpleBLE::BluetoothAddressType Peripheral::address_type() const {
     if (!initialized()) throw Exception::NotInitialized();
 
-    return internal_->address_type();
+    return internal().address_type();
 }
 
-int16_t Peripheral::rssi() {
+int16_t Peripheral::rssi() const {
     if (!initialized()) throw Exception::NotInitialized();
 
-    return internal_->rssi();
+    return internal().rssi();
 }
 
-int16_t Peripheral::tx_power() {
+int16_t Peripheral::tx_power() const {
     if (!initialized()) throw Exception::NotInitialized();
 
-    return internal_->tx_power();
+    return internal().tx_power();
 }
 
-uint16_t Peripheral::mtu() {
+uint16_t Peripheral::mtu() const {
     if (!initialized()) throw Exception::NotInitialized();
 
-    return internal_->mtu();
+    return internal().mtu();
 }
 
 void Peripheral::connect() {
     if (!initialized()) throw Exception::NotInitialized();
 
-    internal_->connect();
+    internal().connect();
 }
 
 void Peripheral::disconnect() {
     if (!initialized()) throw Exception::NotInitialized();
 
-    internal_->disconnect();
+    internal().disconnect();
 }
 
 bool Peripheral::is_connected() {
     if (!initialized()) throw Exception::NotInitialized();
 
-    return internal_->is_connected();
+    return internal().is_connected();
 }
 
 bool Peripheral::is_connectable() {
     if (!initialized()) throw Exception::NotInitialized();
 
-    return internal_->is_connectable();
+    return internal().is_connectable();
 }
 
 bool Peripheral::is_paired() {
     if (!initialized()) throw Exception::NotInitialized();
 
-    return internal_->is_paired();
+    return internal().is_paired();
 }
 
 void Peripheral::unpair() {
     if (!initialized()) throw Exception::NotInitialized();
 
-    internal_->unpair();
+    internal().unpair();
 }
 
 std::vector<Service> Peripheral::services() {
     if (!initialized()) throw Exception::NotInitialized();
 
     if (is_connected()) {
-        return internal_->services();
+        return internal().services();
     } else {
-        return internal_->advertised_services();
+        return internal().advertised_services();
     }
 
-    return internal_->services();
+    return internal().services();
 }
 
 std::map<uint16_t, ByteArray> Peripheral::manufacturer_data() {
     if (!initialized()) throw Exception::NotInitialized();
 
-    return internal_->manufacturer_data();
+    return internal().manufacturer_data();
 }
 
 ByteArray Peripheral::read(BluetoothUUID const& service, BluetoothUUID const& characteristic) {
     if (!initialized()) throw Exception::NotInitialized();
     if (!is_connected()) throw Exception::NotConnected();
 
-    return internal_->read(service, characteristic);
+    return internal().read(service, characteristic);
 }
 
 void Peripheral::write_request(BluetoothUUID const& service, BluetoothUUID const& characteristic,
@@ -115,7 +115,7 @@ void Peripheral::write_request(BluetoothUUID const& service, BluetoothUUID const
     if (!initialized()) throw Exception::NotInitialized();
     if (!is_connected()) throw Exception::NotConnected();
 
-    internal_->write_request(service, characteristic, data);
+    internal().write_request(service, characteristic, data);
 }
 
 void Peripheral::write_command(BluetoothUUID const& service, BluetoothUUID const& characteristic,
@@ -123,7 +123,7 @@ void Peripheral::write_command(BluetoothUUID const& service, BluetoothUUID const
     if (!initialized()) throw Exception::NotInitialized();
     if (!is_connected()) throw Exception::NotConnected();
 
-    internal_->write_command(service, characteristic, data);
+    internal().write_command(service, characteristic, data);
 }
 
 void Peripheral::notify(BluetoothUUID const& service, BluetoothUUID const& characteristic,
@@ -131,7 +131,7 @@ void Peripheral::notify(BluetoothUUID const& service, BluetoothUUID const& chara
     if (!initialized()) throw Exception::NotInitialized();
     if (!is_connected()) throw Exception::NotConnected();
 
-    internal_->notify(service, characteristic, std::move(callback));
+    internal().notify(service, characteristic, std::move(callback));
 }
 
 void Peripheral::indicate(BluetoothUUID const& service, BluetoothUUID const& characteristic,
@@ -139,14 +139,14 @@ void Peripheral::indicate(BluetoothUUID const& service, BluetoothUUID const& cha
     if (!initialized()) throw Exception::NotInitialized();
     if (!is_connected()) throw Exception::NotConnected();
 
-    internal_->indicate(service, characteristic, std::move(callback));
+    internal().indicate(service, characteristic, std::move(callback));
 }
 
 void Peripheral::unsubscribe(BluetoothUUID const& service, BluetoothUUID const& characteristic) {
     if (!initialized()) throw Exception::NotInitialized();
     if (!is_connected()) throw Exception::NotConnected();
 
-    internal_->unsubscribe(service, characteristic);
+    internal().unsubscribe(service, characteristic);
 }
 
 ByteArray Peripheral::read(BluetoothUUID const& service, BluetoothUUID const& characteristic,
@@ -154,7 +154,7 @@ ByteArray Peripheral::read(BluetoothUUID const& service, BluetoothUUID const& ch
     if (!initialized()) throw Exception::NotInitialized();
     if (!is_connected()) throw Exception::NotConnected();
 
-    return internal_->read(service, characteristic, descriptor);
+    return internal().read(service, characteristic, descriptor);
 }
 
 void Peripheral::write(BluetoothUUID const& service, BluetoothUUID const& characteristic,
@@ -162,17 +162,25 @@ void Peripheral::write(BluetoothUUID const& service, BluetoothUUID const& charac
     if (!initialized()) throw Exception::NotInitialized();
     if (!is_connected()) throw Exception::NotConnected();
 
-    internal_->write(service, characteristic, descriptor, data);
+    internal().write(service, characteristic, descriptor, data);
 }
 
 void Peripheral::set_callback_on_connected(std::function<void()> on_connected) {
     if (!initialized()) throw Exception::NotInitialized();
 
-    internal_->set_callback_on_connected(std::move(on_connected));
+    internal().set_callback_on_connected(std::move(on_connected));
 }
 
 void Peripheral::set_callback_on_disconnected(std::function<void()> on_disconnected) {
     if (!initialized()) throw Exception::NotInitialized();
 
-    internal_->set_callback_on_disconnected(std::move(on_disconnected));
+    internal().set_callback_on_disconnected(std::move(on_disconnected));
+}
+
+PeripheralBase &Peripheral::internal() {
+    return *internal_;
+}
+
+const PeripheralBase &Peripheral::internal() const {
+    return *internal_;
 }

--- a/simpleble/src/frontends/base/Service.cpp
+++ b/simpleble/src/frontends/base/Service.cpp
@@ -5,8 +5,12 @@
 
 using namespace SimpleBLE;
 
-BluetoothUUID Service::uuid() { return internal_->uuid(); }
+BluetoothUUID Service::uuid() const { return internal().uuid(); }
 
-ByteArray Service::data() { return internal_->data(); }
+ByteArray Service::data() const { return internal().data(); }
 
-std::vector<Characteristic> Service::characteristics() { return internal_->characteristics(); }
+std::vector<Characteristic> Service::characteristics() const { return internal().characteristics(); }
+
+ServiceBase &Service::internal() { return *internal_; }
+
+const ServiceBase &Service::internal() const { return *internal_; }


### PR DESCRIPTION
Const correctness is important for thread-safety and performance. This commit adds const qualifiers to member functions that do not mutate its object. Furthermore an internal() wrapper function is introduced to force const checks throughout the API.