### PR TITLE
Fix SetDiscoveryFilter function

### DIFF
--- a/simplebluez/src/interfaces/Adapter1.cpp
+++ b/simplebluez/src/interfaces/Adapter1.cpp
@@ -24,57 +24,73 @@ SimpleDBus::Holder Adapter1::GetDiscoveryFilters() {
 }
 
 void Adapter1::SetDiscoveryFilter(DiscoveryFilter filter) {
-    SimpleDBus::Holder properties = SimpleDBus::Holder::create_dict();
+    SimpleDBus::Holder properties = SimpleDBus::Holder::create_array();
 
     if (filter.UUIDs.size() > 0) {
         SimpleDBus::Holder uuids = SimpleDBus::Holder::create_array();
         for (size_t i = 0; i < filter.UUIDs.size(); i++) {
             uuids.array_append(SimpleDBus::Holder::create_string(filter.UUIDs.at(i)));
         }
-        properties.dict_append(SimpleDBus::Holder::Type::ARRAY, "UUIDs", uuids);
+        SimpleDBus::Holder dict = SimpleDBus::Holder::create_dict();
+        dict.dict_append(SimpleDBus::Holder::Type::STRING, "UUIDs", uuids);
+        properties.array_append(dict);
     }
 
     if (filter.RSSI.has_value()) {
-        properties.dict_append(SimpleDBus::Holder::Type::INT16, "RSSI",
-                               SimpleDBus::Holder::create_int16(filter.RSSI.value()));
+        SimpleDBus::Holder dict = SimpleDBus::Holder::create_dict();
+        dict.dict_append(SimpleDBus::Holder::Type::STRING, "RSSI",
+                         SimpleDBus::Holder::create_int16(filter.RSSI.value()));
+        properties.array_append(dict);
     }
 
     if (filter.Pathloss.has_value()) {
-        properties.dict_append(SimpleDBus::Holder::Type::UINT16, "Pathloss",
-                               SimpleDBus::Holder::create_uint16(filter.Pathloss.value()));
+        SimpleDBus::Holder dict = SimpleDBus::Holder::create_dict();
+        dict.dict_append(SimpleDBus::Holder::Type::STRING, "Pathloss",
+                         SimpleDBus::Holder::create_uint16(filter.Pathloss.value()));
+        properties.array_append(dict);
     }
 
-    switch (filter.Transport) {
-        case DiscoveryFilter::TransportType::AUTO: {
-            properties.dict_append(SimpleDBus::Holder::Type::STRING, "Transport",
-                                   SimpleDBus::Holder::create_string("auto"));
-            break;
+    {
+        SimpleDBus::Holder dict = SimpleDBus::Holder::create_dict();
+        switch (filter.Transport) {
+            case DiscoveryFilter::TransportType::AUTO: {
+                dict.dict_append(SimpleDBus::Holder::Type::STRING, "Transport",
+                                 SimpleDBus::Holder::create_string("auto"));
+                break;
+            }
+            case DiscoveryFilter::TransportType::BREDR: {
+                dict.dict_append(SimpleDBus::Holder::Type::STRING, "Transport",
+                                 SimpleDBus::Holder::create_string("bredr"));
+                break;
+            }
+            case DiscoveryFilter::TransportType::LE: {
+                dict.dict_append(SimpleDBus::Holder::Type::STRING, "Transport",
+                                 SimpleDBus::Holder::create_string("le"));
+                break;
+            }
         }
-        case DiscoveryFilter::TransportType::BREDR: {
-            properties.dict_append(SimpleDBus::Holder::Type::STRING, "Transport",
-                                   SimpleDBus::Holder::create_string("bredr"));
-            break;
-        }
-        case DiscoveryFilter::TransportType::LE: {
-            properties.dict_append(SimpleDBus::Holder::Type::STRING, "Transport",
-                                   SimpleDBus::Holder::create_string("le"));
-            break;
-        }
+        properties.array_append(dict);
     }
 
     if (!filter.DuplicateData) {
-        properties.dict_append(SimpleDBus::Holder::Type::BOOLEAN, "DuplicateData",
+        SimpleDBus::Holder dict = SimpleDBus::Holder::create_dict();
+        dict.dict_append(SimpleDBus::Holder::Type::STRING, "DuplicateData",
                                SimpleDBus::Holder::create_boolean(false));
+        properties.array_append(dict);
     }
 
     if (filter.Discoverable) {
-        properties.dict_append(SimpleDBus::Holder::Type::BOOLEAN, "Discoverable",
+        SimpleDBus::Holder dict = SimpleDBus::Holder::create_dict();
+        dict.dict_append(SimpleDBus::Holder::Type::STRING, "Discoverable",
                                SimpleDBus::Holder::create_boolean(false));
+        properties.array_append(dict);
     }
 
     if (filter.Pattern.size() > 0) {
-        properties.dict_append(SimpleDBus::Holder::Type::STRING, "Pattern",
+        SimpleDBus::Holder dict = SimpleDBus::Holder::create_dict();
+        dict.dict_append(SimpleDBus::Holder::Type::STRING, "Pattern",
                                SimpleDBus::Holder::create_string(filter.Pattern));
+        properties.array_append(dict);
     }
 
     auto msg = create_method_call("SetDiscoveryFilter");

--- a/simpledbus/src/base/Message.cpp
+++ b/simpledbus/src/base/Message.cpp
@@ -224,66 +224,66 @@ void Message::_append_argument(DBusMessageIter* iter, Holder& argument, std::str
             auto sig_next = signature.substr(1);
             DBusMessageIter sub_iter;
             dbus_message_iter_open_container(iter, DBUS_TYPE_ARRAY, sig_next.c_str(), &sub_iter);
-            if (sig_next[0] != DBUS_DICT_ENTRY_BEGIN_CHAR) {
-                auto array_contents = argument.get_array();
-                for (auto elem : array_contents) {
+            auto array_contents = argument.get_array();
+            for (auto elem : array_contents) {
+                if (sig_next[0] != DBUS_DICT_ENTRY_BEGIN_CHAR) {
                     _append_argument(&sub_iter, elem, sig_next);
-                }
-            } else {
-                sig_next = sig_next.substr(1, sig_next.length() - 2);
-                auto key_sig = sig_next[0];
-                auto value_sig = sig_next.substr(1);
+                } else {
+                    auto sig_dict = sig_next.substr(1, sig_next.length() - 2);
+                    auto key_sig = sig_dict[0];
+                    auto value_sig = sig_dict.substr(1);
 
-                switch (key_sig) {
-                    case DBUS_TYPE_BYTE: {
-                        auto dict_contents = argument.get_dict_uint8();
-                        MESSAGE_DICT_APPEND_KEY_NUM(key_sig, dict_contents);
-                        break;
-                    }
-                    case DBUS_TYPE_INT16: {
-                        auto dict_contents = argument.get_dict_int16();
-                        MESSAGE_DICT_APPEND_KEY_NUM(key_sig, dict_contents);
-                        break;
-                    }
-                    case DBUS_TYPE_UINT16: {
-                        auto dict_contents = argument.get_dict_uint16();
-                        MESSAGE_DICT_APPEND_KEY_NUM(key_sig, dict_contents);
-                        break;
-                    }
-                    case DBUS_TYPE_INT32: {
-                        auto dict_contents = argument.get_dict_int32();
-                        MESSAGE_DICT_APPEND_KEY_NUM(key_sig, dict_contents);
-                        break;
-                    }
-                    case DBUS_TYPE_UINT32: {
-                        auto dict_contents = argument.get_dict_uint32();
-                        MESSAGE_DICT_APPEND_KEY_NUM(key_sig, dict_contents);
-                        break;
-                    }
-                    case DBUS_TYPE_INT64: {
-                        auto dict_contents = argument.get_dict_int64();
-                        MESSAGE_DICT_APPEND_KEY_NUM(key_sig, dict_contents);
-                        break;
-                    }
-                    case DBUS_TYPE_UINT64: {
-                        auto dict_contents = argument.get_dict_uint64();
-                        MESSAGE_DICT_APPEND_KEY_NUM(key_sig, dict_contents);
-                        break;
-                    }
-                    case DBUS_TYPE_STRING: {
-                        auto dict_contents = argument.get_dict_string();
-                        MESSAGE_DICT_APPEND_KEY_STR(key_sig, dict_contents);
-                        break;
-                    }
-                    case DBUS_TYPE_OBJECT_PATH: {
-                        auto dict_contents = argument.get_dict_object_path();
-                        MESSAGE_DICT_APPEND_KEY_STR(key_sig, dict_contents);
-                        break;
-                    }
-                    case DBUS_TYPE_SIGNATURE: {
-                        auto dict_contents = argument.get_dict_signature();
-                        MESSAGE_DICT_APPEND_KEY_STR(key_sig, dict_contents);
-                        break;
+                    switch (key_sig) {
+                        case DBUS_TYPE_BYTE: {
+                            auto dict_contents = elem.get_dict_uint8();
+                            MESSAGE_DICT_APPEND_KEY_NUM(key_sig, dict_contents);
+                            break;
+                        }
+                        case DBUS_TYPE_INT16: {
+                            auto dict_contents = elem.get_dict_int16();
+                            MESSAGE_DICT_APPEND_KEY_NUM(key_sig, dict_contents);
+                            break;
+                        }
+                        case DBUS_TYPE_UINT16: {
+                            auto dict_contents = elem.get_dict_uint16();
+                            MESSAGE_DICT_APPEND_KEY_NUM(key_sig, dict_contents);
+                            break;
+                        }
+                        case DBUS_TYPE_INT32: {
+                            auto dict_contents = elem.get_dict_int32();
+                            MESSAGE_DICT_APPEND_KEY_NUM(key_sig, dict_contents);
+                            break;
+                        }
+                        case DBUS_TYPE_UINT32: {
+                            auto dict_contents = elem.get_dict_uint32();
+                            MESSAGE_DICT_APPEND_KEY_NUM(key_sig, dict_contents);
+                            break;
+                        }
+                        case DBUS_TYPE_INT64: {
+                            auto dict_contents = elem.get_dict_int64();
+                            MESSAGE_DICT_APPEND_KEY_NUM(key_sig, dict_contents);
+                            break;
+                        }
+                        case DBUS_TYPE_UINT64: {
+                            auto dict_contents = elem.get_dict_uint64();
+                            MESSAGE_DICT_APPEND_KEY_NUM(key_sig, dict_contents);
+                            break;
+                        }
+                        case DBUS_TYPE_STRING: {
+                            auto dict_contents = elem.get_dict_string();
+                            MESSAGE_DICT_APPEND_KEY_STR(key_sig, dict_contents);
+                            break;
+                        }
+                        case DBUS_TYPE_OBJECT_PATH: {
+                            auto dict_contents = elem.get_dict_object_path();
+                            MESSAGE_DICT_APPEND_KEY_STR(key_sig, dict_contents);
+                            break;
+                        }
+                        case DBUS_TYPE_SIGNATURE: {
+                            auto dict_contents = elem.get_dict_signature();
+                            MESSAGE_DICT_APPEND_KEY_STR(key_sig, dict_contents);
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This pull request can be divided into two parts but both are related. The main issue is related to the function SetDiscoveryFilter on simplebluez/Adapter1 class. This function was not setting properly all the arguments of the SetDiscoveryFilter method on Bluez service. On my tests, only the "Transport" field was being set. 

To fix this issue, the function SetDiscoveryFilter had to be refactored to start building an array of dicts instead of a dict. And, the function _append_argument() on simpledbus/Message class was not properly creating a DBus message for an array of dicts. 

Two commits were added to this pull request, one for each class.

