### PR TITLE
Add extended advertising packet scanning to Windows and Android.

### DIFF
--- a/simpleble/CMakeLists.txt
+++ b/simpleble/CMakeLists.txt
@@ -335,6 +335,8 @@ elseif(SIMPLEBLE_BACKEND_ANDROID)
         ${CMAKE_CURRENT_SOURCE_DIR}/src/backends/android/types/android/os/ParcelUUID.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/backends/android/types/android/bluetooth/le/ScanRecord.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/backends/android/types/android/bluetooth/le/ScanResult.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/backends/android/types/android/bluetooth/le/ScanFilter.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/backends/android/types/android/bluetooth/le/ScanSettings.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/backends/android/types/android/util/SparseArray.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/backends/android/types/java/util/Iterator.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/backends/android/types/java/util/List.cpp

--- a/simpleble/src/backends/android/AdapterAndroid.h
+++ b/simpleble/src/backends/android/AdapterAndroid.h
@@ -19,12 +19,13 @@
 
 namespace SimpleBLE {
 
+class BackendAndroid;
 class PeripheralAndroid;
 class Peripheral;
 
 class AdapterAndroid : public AdapterBase {
   public:
-    AdapterAndroid();
+    AdapterAndroid(std::shared_ptr<BackendAndroid> backend);
     virtual ~AdapterAndroid();
 
     virtual void* underlying() const override;
@@ -54,6 +55,8 @@ class AdapterAndroid : public AdapterBase {
     void onScanFailedCallback(JNIEnv* env, jobject thiz, jint error_code);
 
   private:
+    std::shared_ptr<BackendAndroid> backend_;
+
     Android::BluetoothAdapter _btAdapter = Android::BluetoothAdapter::getDefaultAdapter();
     Android::BluetoothScanner _btScanner = _btAdapter.getBluetoothLeScanner();
     Android::Bridge::ScanCallback _btScanCallback;

--- a/simpleble/src/backends/android/BackendAndroid.cpp
+++ b/simpleble/src/backends/android/BackendAndroid.cpp
@@ -17,7 +17,7 @@ std::shared_ptr<BackendAndroid> BACKEND_ANDROID() { return BackendAndroid::get()
 BackendAndroid::BackendAndroid(buildToken) {
     SimpleJNI::Registrar::get().preload(SimpleJNI::VM::env());
 
-    _adapter = std::make_shared<AdapterAndroid>();
+    _adapter = std::make_shared<AdapterAndroid>(shared_from_this());
 }
 
 std::string BackendAndroid::name() const noexcept { return "Android"; }

--- a/simpleble/src/backends/android/types/android/bluetooth/le/BluetoothScanner.cpp
+++ b/simpleble/src/backends/android/types/android/bluetooth/le/BluetoothScanner.cpp
@@ -10,6 +10,7 @@ namespace Android {
 SimpleJNI::GlobalRef<jclass> BluetoothScanner::_cls;
 jmethodID BluetoothScanner::_constructor = nullptr;
 jmethodID BluetoothScanner::_method_startScan = nullptr;
+jmethodID BluetoothScanner::_method_startScan_with_settings = nullptr;
 jmethodID BluetoothScanner::_method_stopScan = nullptr;
 jmethodID BluetoothScanner::_method_toString = nullptr;
 
@@ -20,6 +21,7 @@ const SimpleJNI::JNIDescriptor BluetoothScanner::descriptor{
     {                                          // Methods to preload
      {"<init>", "()V", &_constructor},
      {"startScan", "(Landroid/bluetooth/le/ScanCallback;)V", &_method_startScan},
+     {"startScan", "(Ljava/util/List;Landroid/bluetooth/le/ScanSettings;Landroid/bluetooth/le/ScanCallback;)V", &_method_startScan_with_settings},
      {"stopScan", "(Landroid/bluetooth/le/ScanCallback;)V", &_method_stopScan},
      {"toString", "()Ljava/lang/String;", &_method_toString}
     }};
@@ -31,6 +33,12 @@ BluetoothScanner::BluetoothScanner(SimpleJNI::Object<SimpleJNI::GlobalRef, jobje
 void BluetoothScanner::startScan(Bridge::ScanCallback& callback) {
     if (!_obj) throw std::runtime_error("BluetoothScanner is not initialized");
     _obj.call_void_method(_method_startScan, callback.get());
+}
+
+void BluetoothScanner::startScan(List& filters, ScanSettings& settings,
+                                   Bridge::ScanCallback& callback) {
+    if (!_obj) throw std::runtime_error("BluetoothScanner is not initialized");
+    _obj.call_void_method(_method_startScan_with_settings, filters.get(), settings.get(), callback.get());
 }
 
 void BluetoothScanner::stopScan(Bridge::ScanCallback& callback) {

--- a/simpleble/src/backends/android/types/android/bluetooth/le/BluetoothScanner.h
+++ b/simpleble/src/backends/android/types/android/bluetooth/le/BluetoothScanner.h
@@ -2,6 +2,9 @@
 
 #include "simplejni/Common.hpp"
 #include "bridge/ScanCallback.h"
+#include "ScanFilter.h"
+#include "ScanSettings.h"
+#include "backends/android/types/java/util/List.h"
 
 namespace SimpleBLE {
 namespace Android {
@@ -11,6 +14,7 @@ class BluetoothScanner {
     BluetoothScanner(SimpleJNI::Object<SimpleJNI::GlobalRef, jobject> obj);
 
     void startScan(Bridge::ScanCallback& callback);
+    void startScan(List& filters, ScanSettings& settings, Bridge::ScanCallback& callback);
     void stopScan(Bridge::ScanCallback& callback);
 
     std::string toString();
@@ -25,6 +29,7 @@ class BluetoothScanner {
     static SimpleJNI::GlobalRef<jclass> _cls;
     static jmethodID _constructor;
     static jmethodID _method_startScan;
+    static jmethodID _method_startScan_with_settings;
     static jmethodID _method_stopScan;
     static jmethodID _method_toString;
 

--- a/simpleble/src/backends/android/types/android/bluetooth/le/ScanFilter.cpp
+++ b/simpleble/src/backends/android/types/android/bluetooth/le/ScanFilter.cpp
@@ -1,0 +1,42 @@
+#include "ScanFilter.h"
+#include <simplejni/Registry.hpp>
+
+namespace SimpleBLE {
+namespace Android {
+
+// ScanFilter
+SimpleJNI::GlobalRef<jclass> ScanFilter::_cls;
+jmethodID ScanFilter::_constructor;
+
+const SimpleJNI::JNIDescriptor ScanFilter::descriptor{
+    "android/bluetooth/le/ScanFilter",
+    &ScanFilter::_cls,
+    {
+        {"<init>", "()V", &ScanFilter::_constructor},
+    }
+};
+const SimpleJNI::AutoRegister<ScanFilter> ScanFilter::registrar{&ScanFilter::descriptor};
+
+// ScanFilter::Builder
+SimpleJNI::GlobalRef<jclass> ScanFilter::Builder::_cls;
+jmethodID ScanFilter::Builder::_constructor;
+jmethodID ScanFilter::Builder::_method_build;
+
+const SimpleJNI::JNIDescriptor ScanFilter::Builder::descriptor{
+    "android/bluetooth/le/ScanFilter$Builder",
+    &ScanFilter::Builder::_cls,
+    {
+        {"<init>", "()V", &ScanFilter::Builder::_constructor},
+        {"build", "()Landroid/bluetooth/le/ScanFilter;", &ScanFilter::Builder::_method_build},
+    }
+};
+const SimpleJNI::AutoRegister<ScanFilter::Builder> ScanFilter::Builder::registrar{&ScanFilter::Builder::descriptor};
+
+ScanFilter::Builder::Builder() : SimpleJNI::Object<SimpleJNI::GlobalRef>(SimpleJNI::Object<SimpleJNI::LocalRef>(SimpleJNI::VM::env()->NewObject(_cls.get(), _constructor)).to_global()) {}
+
+ScanFilter ScanFilter::Builder::build() {
+    return ScanFilter(call_object_method(_method_build));
+}
+
+}  // namespace Android
+}  // namespace SimpleBLE

--- a/simpleble/src/backends/android/types/android/bluetooth/le/ScanFilter.h
+++ b/simpleble/src/backends/android/types/android/bluetooth/le/ScanFilter.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <simplejni/Common.hpp>
+#include <simplejni/Registry.hpp>
+
+namespace SimpleBLE {
+namespace Android {
+
+class ScanFilter : public SimpleJNI::Object<SimpleJNI::GlobalRef> {
+  public:
+    using SimpleJNI::Object<SimpleJNI::GlobalRef>::Object;
+
+    class Builder : public SimpleJNI::Object<SimpleJNI::GlobalRef> {
+      public:
+        using SimpleJNI::Object<SimpleJNI::GlobalRef>::Object;
+        Builder();
+        ScanFilter build();
+
+      private:
+        friend class ScanFilter;
+        static SimpleJNI::GlobalRef<jclass> _cls;
+        static jmethodID _constructor;
+        static jmethodID _method_build;
+        static const SimpleJNI::JNIDescriptor descriptor;
+        static const SimpleJNI::AutoRegister<Builder> registrar;
+    };
+
+  private:
+    friend class Builder;
+    static SimpleJNI::GlobalRef<jclass> _cls;
+    static jmethodID _constructor;
+    static const SimpleJNI::JNIDescriptor descriptor;
+    static const SimpleJNI::AutoRegister<ScanFilter> registrar;
+};
+
+}  // namespace Android
+}  // namespace SimpleBLE

--- a/simpleble/src/backends/android/types/android/bluetooth/le/ScanSettings.cpp
+++ b/simpleble/src/backends/android/types/android/bluetooth/le/ScanSettings.cpp
@@ -1,0 +1,49 @@
+#include "ScanSettings.h"
+#include <simplejni/Registry.hpp>
+
+namespace SimpleBLE {
+namespace Android {
+
+// ScanSettings
+SimpleJNI::GlobalRef<jclass> ScanSettings::_cls;
+jmethodID ScanSettings::_constructor;
+
+const SimpleJNI::JNIDescriptor ScanSettings::descriptor{
+    "android/bluetooth/le/ScanSettings",
+    &ScanSettings::_cls,
+    {
+        {"<init>", "()V", &ScanSettings::_constructor},
+    }
+};
+const SimpleJNI::AutoRegister<ScanSettings> ScanSettings::registrar{&ScanSettings::descriptor};
+
+// ScanSettings::Builder
+SimpleJNI::GlobalRef<jclass> ScanSettings::Builder::_cls;
+jmethodID ScanSettings::Builder::_constructor;
+jmethodID ScanSettings::Builder::_method_setLegacy;
+jmethodID ScanSettings::Builder::_method_build;
+
+const SimpleJNI::JNIDescriptor ScanSettings::Builder::descriptor{
+    "android/bluetooth/le/ScanSettings$Builder",
+    &ScanSettings::Builder::_cls,
+    {
+        {"<init>", "()V", &ScanSettings::Builder::_constructor},
+        {"setLegacy", "(Z)Landroid/bluetooth/le/ScanSettings$Builder;", &ScanSettings::Builder::_method_setLegacy},
+        {"build", "()Landroid/bluetooth/le/ScanSettings;", &ScanSettings::Builder::_method_build},
+    }
+};
+const SimpleJNI::AutoRegister<ScanSettings::Builder> ScanSettings::Builder::registrar{&ScanSettings::Builder::descriptor};
+
+ScanSettings::Builder::Builder() : SimpleJNI::Object<SimpleJNI::GlobalRef>(SimpleJNI::Object<SimpleJNI::LocalRef>(SimpleJNI::VM::env()->NewObject(_cls.get(), _constructor)).to_global()) {}
+
+ScanSettings::Builder& ScanSettings::Builder::setLegacy(bool legacy) {
+    call_object_method(_method_setLegacy, (jboolean)legacy);
+    return *this;
+}
+
+ScanSettings ScanSettings::Builder::build() {
+    return ScanSettings(call_object_method(_method_build));
+}
+
+}  // namespace Android
+}  // namespace SimpleBLE

--- a/simpleble/src/backends/android/types/android/bluetooth/le/ScanSettings.h
+++ b/simpleble/src/backends/android/types/android/bluetooth/le/ScanSettings.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <simplejni/Common.hpp>
+#include <simplejni/Registry.hpp>
+
+namespace SimpleBLE {
+namespace Android {
+
+class ScanSettings : public SimpleJNI::Object<SimpleJNI::GlobalRef> {
+  public:
+    using SimpleJNI::Object<SimpleJNI::GlobalRef>::Object;
+
+    class Builder : public SimpleJNI::Object<SimpleJNI::GlobalRef> {
+      public:
+        using SimpleJNI::Object<SimpleJNI::GlobalRef>::Object;
+        Builder();
+        Builder& setLegacy(bool legacy);
+        ScanSettings build();
+
+      private:
+        friend class ScanSettings;
+        static SimpleJNI::GlobalRef<jclass> _cls;
+        static jmethodID _constructor;
+        static jmethodID _method_setLegacy;
+        static jmethodID _method_build;
+        static const SimpleJNI::JNIDescriptor descriptor;
+        static const SimpleJNI::AutoRegister<Builder> registrar;
+    };
+
+  private:
+    friend class Builder;
+    static SimpleJNI::GlobalRef<jclass> _cls;
+    static jmethodID _constructor;
+    static const SimpleJNI::JNIDescriptor descriptor;
+    static const SimpleJNI::AutoRegister<ScanSettings> registrar;
+};
+
+}  // namespace Android
+}  // namespace SimpleBLE

--- a/simpleble/src/backends/android/types/java/util/List.cpp
+++ b/simpleble/src/backends/android/types/java/util/List.cpp
@@ -4,6 +4,26 @@
 namespace SimpleBLE {
 namespace Android {
 
+namespace {
+    SimpleJNI::GlobalRef<jclass> array_list_cls;
+    jmethodID array_list_constructor;
+    jmethodID array_list_add;
+
+    struct ArrayList {
+        static const SimpleJNI::JNIDescriptor descriptor;
+    };
+
+    const SimpleJNI::JNIDescriptor ArrayList::descriptor = {
+        "java/util/ArrayList",
+        &array_list_cls,
+        {
+            {"<init>", "()V", &array_list_constructor},
+            {"add", "(Ljava/lang/Object;)Z", &array_list_add},
+        }
+    };
+    const SimpleJNI::AutoRegister<ArrayList> array_list_registrar{&ArrayList::descriptor};
+}
+
 SimpleJNI::GlobalRef<jclass> List::_cls;
 jmethodID List::_method_iterator = nullptr;
 
@@ -19,10 +39,20 @@ const SimpleJNI::AutoRegister<List> List::registrar{&descriptor};
 
 List::List(SimpleJNI::Object<SimpleJNI::GlobalRef, jobject> obj) : _obj(obj) {}
 
+List::List() : _obj(SimpleJNI::Object<SimpleJNI::LocalRef>(SimpleJNI::VM::env()->NewObject(array_list_cls.get(), array_list_constructor)).to_global()) {}
+
+void List::add(SimpleJNI::Object<SimpleJNI::GlobalRef, jobject>& obj) {
+    _obj.call_boolean_method(array_list_add, obj.get());
+}
+
 Iterator List::iterator() {
     if (!_obj) throw std::runtime_error("List is not initialized");
     SimpleJNI::Object<SimpleJNI::LocalRef> iterator_obj = _obj.call_object_method(_method_iterator);
     return Iterator(iterator_obj.to_global());
+}
+
+jobject List::get() const {
+    return _obj.get();
 }
 
 }  // namespace Android

--- a/simpleble/src/backends/android/types/java/util/List.h
+++ b/simpleble/src/backends/android/types/java/util/List.h
@@ -11,8 +11,10 @@ namespace Android {
 class List {
   public:
     List(SimpleJNI::Object<SimpleJNI::GlobalRef, jobject> obj);
-
+    List();
+    void add(SimpleJNI::Object<SimpleJNI::GlobalRef, jobject>& obj);
     Iterator iterator();
+    jobject get() const;
 
   private:
     static SimpleJNI::GlobalRef<jclass> _cls;

--- a/simpleble/src/backends/windows/AdapterWindows.cpp
+++ b/simpleble/src/backends/windows/AdapterWindows.cpp
@@ -40,6 +40,7 @@ AdapterWindows::AdapterWindows(std::string device_id)
 
     // Configure the scanner object
     scanner_ = Advertisement::BluetoothLEAdvertisementWatcher();
+    scanner_.AllowExtendedAdvertisements(true);
 
     // Register member functions directly as callback handlers
     radio_state_changed_token_ = radio_.StateChanged({this, &AdapterWindows::on_power_state_changed});
@@ -148,11 +149,7 @@ SharedPtrVector<PeripheralBase> AdapterWindows::get_paired_peripherals() {
                 peripherals.push_back(this->peripherals_.at(address));
             } catch (const winrt::hresult_error& e) {
                 SIMPLEBLE_LOG_ERROR(fmt::format("WinRT error processing paired device {} : {}", winrt::to_string(dev_info.Id()), winrt::to_string(e.message())));
-
-                // NOTE: For debugging purposes, we'll print the error message and continue.
-                fmt::print("WinRT error processing paired device {} : {}", winrt::to_string(dev_info.Id()), winrt::to_string(e.message()));
-                //throw Exception::WinRTException(e.code().value, winrt::to_string(e.message()));
-                continue;
+                throw Exception::WinRTException(e.code().value, winrt::to_string(e.message()));
             }
         }
         return peripherals;
@@ -183,11 +180,7 @@ SharedPtrVector<PeripheralBase> AdapterWindows::get_connected_peripherals() {
                 peripherals.push_back(this->peripherals_.at(address));
             } catch (const winrt::hresult_error& e) {
                 SIMPLEBLE_LOG_ERROR(fmt::format("WinRT error processing connected device {} : {}", winrt::to_string(dev_info.Id()), winrt::to_string(e.message())));
-
-                // NOTE: For debugging purposes, we'll print the error message and continue.
-                fmt::print("WinRT error processing connected device {} : {}", winrt::to_string(dev_info.Id()), winrt::to_string(e.message()));
-                // throw Exception::WinRTException(e.code().value, winrt::to_string(e.message()));
-                continue;
+                throw Exception::WinRTException(e.code().value, winrt::to_string(e.message()));
             }
         }
         return peripherals;


### PR DESCRIPTION
Hi! I found out that SimpleBLE only supports legacy advertisement packet scanning, at least on Windows and Android, so I have added functionality to scan for extended advertisement packets in this pull request.