### PR TITLE
Fix advertising data handling to update manufacturer data correctly

### DIFF
--- a/simpleble/src/backends/macos/PeripheralMac.mm
+++ b/simpleble/src/backends/macos/PeripheralMac.mm
@@ -60,9 +60,11 @@ uint16_t PeripheralMac::mtu() {
 
 void PeripheralMac::update_advertising_data(advertising_data_t advertising_data) {
     is_connectable_ = advertising_data.connectable;
-    manufacturer_data_ = advertising_data.manufacturer_data;
     rssi_ = advertising_data.rssi;
     tx_power_ = advertising_data.tx_power;
+
+    advertising_data.manufacturer_data.merge(manufacturer_data_);
+    manufacturer_data_ = advertising_data.manufacturer_data;
 
     advertising_data.service_data.merge(service_data_);
     service_data_ = advertising_data.service_data;

--- a/simpleble/src/backends/windows/PeripheralWindows.cpp
+++ b/simpleble/src/backends/windows/PeripheralWindows.cpp
@@ -85,6 +85,8 @@ void PeripheralWindows::update_advertising_data(advertising_data_t advertising_d
     rssi_ = advertising_data.rssi;
     tx_power_ = advertising_data.tx_power;
     address_type_ = advertising_data.address_type;
+
+    advertising_data.manufacturer_data.merge(manufacturer_data_);
     manufacturer_data_ = advertising_data.manufacturer_data;
 
     advertising_data.service_data.merge(service_data_);


### PR DESCRIPTION
# Summary

- Fix manufacturer data being cleared when scan update events arrive with empty manufacturer data
- Apply the same merge pattern already used for `service_data` to `manufacturer_data`
- Affects Windows and macOS backends

## Problem

During BLE scanning, `manufacturer_data` was captured correctly on the first advertising event but then erased on subsequent updates. This happened because `update_advertising_data()` performed a direct assignment:

```cpp
manufacturer_data_ = advertising_data.manufacturer_data;
```

When an advertising event arrives without manufacturer data sections, `advertising_data.manufacturer_data` is empty, and the assignment clears the previously captured data.

## Solution

Use the same merge pattern already implemented for `service_data`:

```cpp
advertising_data.manufacturer_data.merge(manufacturer_data_);
manufacturer_data_ = advertising_data.manufacturer_data;
```

This ensures:
- New manufacturer data takes precedence when present
- Existing data is preserved when the incoming event has no manufacturer data
- Multiple company IDs from different events accumulate correctly

## Files Changed

- `simpleble/src/backends/windows/PeripheralWindows.cpp`
- `simpleble/src/backends/macos/PeripheralMac.mm`

## Related Issue

Fixes #269

