### PR TITLE
Fix comma in docs/content/docs/meta.json

### DIFF
--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -46,6 +46,6 @@
     "---SimpleAIBLE---",
     "simpleaible/mcp",
     "simpleaible/http",
-    "simpleaible/skills",
+    "simpleaible/skills"
   ]
 }


### PR DESCRIPTION
Running the docs dev server fails due to invalid JSON in docs/content/docs/meta.json, concerning 

`"simpleaible/skills",`

which when `npm run dev` is run, it crashes when parsing the sidebar metadata.

Removing the comma fixes the issue and allows the docs server to start correctly.