### PR TITLE
Potential fix for code scanning alert no. 35: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci_smoketest.yml
+++ b/.github/workflows/ci_smoketest.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build-cpp:
     runs-on: ${{ matrix.config.runner-os }}


### PR DESCRIPTION
Potential fix for [https://github.com/simpleble/simpleble/security/code-scanning/35](https://github.com/simpleble/simpleble/security/code-scanning/35)

Add an explicit top-level `permissions` block in `.github/workflows/ci_smoketest.yml` so all jobs inherit least-privilege token access unless overridden.  
Best single fix: define:

```yml
permissions:
  contents: read
```

at the workflow root (after `on:` and before `jobs:`). This preserves existing functionality for the shown build/test jobs (checkout and builds) while preventing implicit broader token scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
