### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -1,5 +1,8 @@
 name: CI Main
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:
@@ -122,6 +125,8 @@ jobs:
   publish-release:
     needs: [simpleble, simplepyble, simpleaible, simplejavable, simpledroidble, simplecble, simplersble]
     if: github.ref == 'refs/heads/main' || github.event_name == 'release'
+    permissions:
+      contents: write
     runs-on: ubuntu-22.04
     steps:
 


### PR DESCRIPTION
Potential fix for [https://github.com/simpleble/simpleble/security/code-scanning/19](https://github.com/simpleble/simpleble/security/code-scanning/19)

Add explicit `permissions` to `.github/workflows/ci_main.yml`:

1. **At workflow root** (near `name`/`on`): set minimal default permissions for all jobs, e.g. `contents: read`.
2. **At `publish-release` job**: override with the minimum needed to upload release assets, i.e. `contents: write`.

This preserves existing behavior while enforcing least privilege:
- Most jobs remain read-only.
- Only the release-uploading job gets write access to repository contents/releases.

No imports, methods, or dependencies are needed—just YAML key additions in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
