### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   clang-format:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Potential fix for [https://github.com/simpleble/simpleble/security/code-scanning/1](https://github.com/simpleble/simpleble/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so it applies to both `clang-format` and `cppcheck` jobs without changing behavior.  
For this workflow, `contents: read` is the minimal and appropriate permission (needed for `actions/checkout`). No additional write scopes are required for the shown steps.

**File to edit:** `.github/workflows/ci_lint.yml`  
**Change location:** After the `on:` section (or before `jobs:`), add:

```yml
permissions:
  contents: read
```

No imports, methods, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
