### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci_linux_internals.yml
+++ b/.github/workflows/ci_linux_internals.yml
@@ -10,6 +10,9 @@ on:
         default: '["simpledbus","simplebluez"]'
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   # tests:
   #   runs-on: ubuntu-22.04


### PR DESCRIPTION
Potential fix for [https://github.com/simpleble/simpleble/security/code-scanning/6](https://github.com/simpleble/simpleble/security/code-scanning/6)

Add an explicit top-level `permissions` block in `.github/workflows/ci_linux_internals.yml` so all jobs inherit least-privilege token access by default.

Best fix here (without changing functionality): add

```yml
permissions:
  contents: read
```

directly under the `on:` section (or immediately after `name:`), before `jobs:`. This preserves existing workflow behavior (`actions/checkout` still works) while preventing accidental write-capable token scopes from defaults.

No imports, methods, or dependencies are needed—just YAML workflow metadata change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
