### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci_simpledroidble.yml
+++ b/.github/workflows/ci_simpledroidble.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
 
   build-lib:


### PR DESCRIPTION
Potential fix for [https://github.com/simpleble/simpleble/security/code-scanning/9](https://github.com/simpleble/simpleble/security/code-scanning/9)

Add an explicit top-level `permissions` block in `.github/workflows/ci_simpledroidble.yml` so all jobs inherit least-privilege token access.

Best fix (without changing functionality): insert at workflow root (after `on:` section and before `jobs:`):

- `permissions:`
  - `contents: read`

This satisfies checkout and typical read-only build tasks, documents intent, and prevents accidental privilege expansion if repo/org defaults change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
