### PR TITLE
Use C++20 when targeting MSVC.

### DIFF
--- a/simpleble/CMakeLists.txt
+++ b/simpleble/CMakeLists.txt
@@ -75,6 +75,11 @@ set_target_properties(simpleble PROPERTIES
     MINSIZEREL_POSTFIX "-minsizerel"
     DEBUG_POSTFIX "-debug")
 
+if(MSVC)
+    # avoid <experimental/coroutine> being triggered by winrt/base.h which fails for MSVC 19.51+`
+    set_target_properties(simpleble PROPERTIES CXX_STANDARD 20)
+endif()
+
 generate_export_header(
     simpleble
     BASE_NAME simpleble


### PR DESCRIPTION
In Visual Studio 2026 18.6.0 / MSVC 19.51+, <experimental/coroutine> is deprecated in favor of C++20 coroutine support. When built with a verison older than that, <winrt/base.h> ends up including that header, which triggers:

```console
C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\VC\Tools\MSVC\14.51.36231\include\experimental/coroutine(37): error C2338: static assertion failed: 'error STL1011: The /await compiler option, <experimental/coroutine>, <experimental/generator>, and <experimental/resumable> are deprecated by Microsoft and will be REMOVED SOON. They are superseded by the C++20 <coroutine> and C++23 <generator> headers. You can define _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS to suppress this error for now.'
```

Using '20 avoids this.