### PR TITLE
feat(android): add configurable MTU request on connection

### DIFF
--- a/simpleble/include/simpleble/Config.h
+++ b/simpleble/include/simpleble/Config.h
@@ -50,7 +50,14 @@ namespace Android {
 
     extern SIMPLEBLE_EXPORT ConnectionPriorityRequest connection_priority_request;
 
-    static void reset() { connection_priority_request = ConnectionPriorityRequest::DISABLED; }
+    // MTU to request on connection (0 = disabled, leave to Android's 23-byte default).
+    // BLE 4.2+ negotiates up to 517; older peripherals support 23-185.
+    extern SIMPLEBLE_EXPORT int mtu_request;
+
+    static void reset() {
+        connection_priority_request = ConnectionPriorityRequest::DISABLED;
+        mtu_request = 0;
+    }
 }  // namespace Android
 
 namespace Dongl {

--- a/simpleble/src/Config.cpp
+++ b/simpleble/src/Config.cpp
@@ -17,6 +17,7 @@ namespace Config {
 
     namespace Android {
         ConnectionPriorityRequest connection_priority_request = ConnectionPriorityRequest::DISABLED;
+        int mtu_request = 0;
     }  // namespace Android
 
     namespace Dongl {

--- a/simpleble/src/backends/android/PeripheralAndroid.cpp
+++ b/simpleble/src/backends/android/PeripheralAndroid.cpp
@@ -23,6 +23,12 @@ PeripheralAndroid::PeripheralAndroid(Android::BluetoothDevice device) : _device(
                 _gatt.requestConnectionPriority(static_cast<int>(Config::Android::connection_priority_request));
             }
 
+            // Optionally request a larger ATT MTU before service discovery. Android
+            // defaults to 23 bytes, which truncates larger characteristic payloads.
+            if (Config::Android::mtu_request > 0) {
+                _gatt.requestMtu(Config::Android::mtu_request);
+            }
+
             // If a connection has been established, request service discovery.
             _gatt.discoverServices();
         } else {

--- a/simpleble/src/backends/android/types/android/bluetooth/BluetoothGatt.cpp
+++ b/simpleble/src/backends/android/types/android/bluetooth/BluetoothGatt.cpp
@@ -19,6 +19,7 @@ jmethodID BluetoothGatt::_method_setCharacteristicNotification = nullptr;
 jmethodID BluetoothGatt::_method_writeCharacteristic = nullptr;
 jmethodID BluetoothGatt::_method_writeDescriptor = nullptr;
 jmethodID BluetoothGatt::_method_requestConnectionPriority = nullptr;
+jmethodID BluetoothGatt::_method_requestMtu = nullptr;
 // Define the JNI descriptor
 const SimpleJNI::JNIDescriptor BluetoothGatt::descriptor{
     "android/bluetooth/BluetoothGatt", // Java class name
@@ -34,7 +35,8 @@ const SimpleJNI::JNIDescriptor BluetoothGatt::descriptor{
         {"setCharacteristicNotification", "(Landroid/bluetooth/BluetoothGattCharacteristic;Z)Z", &_method_setCharacteristicNotification},
         {"writeCharacteristic", "(Landroid/bluetooth/BluetoothGattCharacteristic;)Z", &_method_writeCharacteristic},
         {"writeDescriptor", "(Landroid/bluetooth/BluetoothGattDescriptor;)Z", &_method_writeDescriptor},
-        {"requestConnectionPriority", "(I)Z", &_method_requestConnectionPriority}
+        {"requestConnectionPriority", "(I)Z", &_method_requestConnectionPriority},
+        {"requestMtu", "(I)Z", &_method_requestMtu}
     }};
 
 const SimpleJNI::AutoRegister<BluetoothGatt> BluetoothGatt::registrar{&descriptor};
@@ -109,6 +111,11 @@ bool BluetoothGatt::writeDescriptor(BluetoothGattDescriptor descriptor) {
 bool BluetoothGatt::requestConnectionPriority(int connectionPriority) {
     if (!_obj) throw std::runtime_error("BluetoothGatt is not initialized");
     return _obj.call_boolean_method(_method_requestConnectionPriority, connectionPriority);
+}
+
+bool BluetoothGatt::requestMtu(int mtu) {
+    if (!_obj) throw std::runtime_error("BluetoothGatt is not initialized");
+    return _obj.call_boolean_method(_method_requestMtu, mtu);
 }
 
 }  // namespace Android

--- a/simpleble/src/backends/android/types/android/bluetooth/BluetoothGatt.h
+++ b/simpleble/src/backends/android/types/android/bluetooth/BluetoothGatt.h
@@ -42,7 +42,7 @@ class BluetoothGatt {
     // void readPhy();
     // bool readRemoteRssi();
     bool requestConnectionPriority(int connectionPriority);
-    // bool requestMtu(int mtu);
+    bool requestMtu(int mtu);
     bool setCharacteristicNotification(BluetoothGattCharacteristic characteristic, bool enable);
     // void setPreferredPhy(int txPhy, int rxPhy, int phyOptions);
     bool writeCharacteristic(BluetoothGattCharacteristic characteristic);
@@ -66,6 +66,7 @@ class BluetoothGatt {
     static jmethodID _method_writeCharacteristic;
     static jmethodID _method_writeDescriptor;
     static jmethodID _method_requestConnectionPriority;
+    static jmethodID _method_requestMtu;
     // JNI descriptor for auto-registration
     static const SimpleJNI::JNIDescriptor descriptor;
     static const SimpleJNI::AutoRegister<BluetoothGatt> registrar;


### PR DESCRIPTION
## Summary

Android BLE connections default to a **23-byte ATT MTU**, which silently truncates any characteristic payload larger than 20 bytes. There is currently no way in SimpleBLE to request a larger MTU on Android — `BluetoothGatt.requestMtu()` exists in the codebase only as a commented-out stub (`// bool requestMtu(int mtu);` in `BluetoothGatt.h`).

This PR implements that stub and exposes it through a small config option, mirroring the existing `Config::Android::connection_priority_request` pattern.

## Changes

- **`Config::Android::mtu_request`** — new option, `int`, **default `0` = disabled** (no behaviour change unless explicitly set).
- **`BluetoothGatt::requestMtu(int)`** — implements the previously stubbed JNI binding (`requestMtu(I)Z`).
- **`PeripheralAndroid`** — when `mtu_request > 0`, requests the MTU right after connection and before service discovery, next to the existing connection-priority request.

```cpp
// Application usage:
SimpleBLE::Config::Android::mtu_request = 517; // BLE 4.2+ max; e.g. 185 for older devices
```

## Behaviour & compatibility

- **Opt-in and backward compatible** — with the default `0`, nothing changes; Android keeps negotiating its 23-byte default.
- Scoped to the Android backend only; other platforms are untouched.
- `reset()` restores `mtu_request = 0` like the other Android config fields.

## Notes

- Android negotiates the actual MTU with the peripheral, so the granted value may be lower than requested; applications can read it back via `Peripheral::mtu()`.
- Motivation: an app sending encrypted BLE messages (130+ bytes) needs a larger MTU on Android; the CoreBluetooth/WinRT/BlueZ backends negotiate larger MTUs automatically, but Android requires an explicit `requestMtu()` call.

Happy to adjust naming/placement to match maintainer preferences. I understand a signed CLA is required and will complete that.