### PR TITLE
feat: expose additional characteristic properties

### DIFF
--- a/simpleble/CMakeLists.txt
+++ b/simpleble/CMakeLists.txt
@@ -484,6 +484,7 @@ if(SIMPLEBLE_TEST)
 
     add_executable(simpleble_test
         ${CMAKE_CURRENT_SOURCE_DIR}/test/src/main.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/src/test_characteristic.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test/src/test_utils.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test/src/test_bytearray.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test/src/test_buffer_overflow.cpp)

--- a/simpleble/include/simpleble/Characteristic.h
+++ b/simpleble/include/simpleble/Characteristic.h
@@ -28,6 +28,9 @@ class SIMPLEBLE_EXPORT Characteristic {
     bool can_write_command();
     bool can_notify();
     bool can_indicate();
+    bool can_broadcast();
+    bool can_write_authenticated_signed();
+    bool has_extended_properties();
 
   protected:
     CharacteristicBase* operator->();

--- a/simpleble/src/backends/android/PeripheralAndroid.cpp
+++ b/simpleble/src/backends/android/PeripheralAndroid.cpp
@@ -139,10 +139,13 @@ SharedPtrVector<ServiceBase> PeripheralAndroid::available_services() {
             bool can_write_command = flags & Android::BluetoothGattCharacteristic::PROPERTY_WRITE_NO_RESPONSE;
             bool can_notify = flags & Android::BluetoothGattCharacteristic::PROPERTY_NOTIFY;
             bool can_indicate = flags & Android::BluetoothGattCharacteristic::PROPERTY_INDICATE;
+            bool can_broadcast = flags & Android::BluetoothGattCharacteristic::PROPERTY_BROADCAST;
+            bool can_write_authenticated_signed = flags & Android::BluetoothGattCharacteristic::PROPERTY_SIGNED_WRITE;
+            bool has_extended_properties = flags & Android::BluetoothGattCharacteristic::PROPERTY_EXTENDED_PROPS;
 
-            characteristic_list.push_back(
-                std::make_shared<CharacteristicBase>(characteristic.getUuid(), descriptor_list, can_read,
-                                                     can_write_request, can_write_command, can_notify, can_indicate));
+            characteristic_list.push_back(std::make_shared<CharacteristicBase>(
+                characteristic.getUuid(), descriptor_list, can_read, can_write_request, can_write_command, can_notify,
+                can_indicate, can_broadcast, can_write_authenticated_signed, has_extended_properties));
         }
 
         service_list.push_back(std::make_shared<ServiceBase>(service.getUuid(), characteristic_list));

--- a/simpleble/src/backends/android/types/android/bluetooth/BluetoothGattCharacteristic.h
+++ b/simpleble/src/backends/android/types/android/bluetooth/BluetoothGattCharacteristic.h
@@ -31,9 +31,12 @@ class BluetoothGattCharacteristic {
 
     SimpleJNI::Object<SimpleJNI::GlobalRef, jobject> getObject() const { return _obj; }
 
+    static const int PROPERTY_BROADCAST = 0x00000001;
     static const int PROPERTY_INDICATE = 0x00000020;
     static const int PROPERTY_NOTIFY = 0x00000010;
     static const int PROPERTY_READ = 0x00000002;
+    static const int PROPERTY_SIGNED_WRITE = 0x00000040;
+    static const int PROPERTY_EXTENDED_PROPS = 0x00000080;
     static const int PROPERTY_WRITE = 0x00000008;
     static const int PROPERTY_WRITE_NO_RESPONSE = 0x00000004;
 

--- a/simpleble/src/backends/common/CharacteristicBase.cpp
+++ b/simpleble/src/backends/common/CharacteristicBase.cpp
@@ -8,14 +8,18 @@ using namespace SimpleBLE;
 
 CharacteristicBase::CharacteristicBase(const BluetoothUUID& uuid, SharedPtrVector<DescriptorBase> descriptors,
                                        bool can_read, bool can_write_request, bool can_write_command, bool can_notify,
-                                       bool can_indicate)
+                                       bool can_indicate, bool can_broadcast, bool can_write_authenticated_signed,
+                                       bool has_extended_properties)
     : uuid_(uuid),
       descriptors_(descriptors),
       can_read_(can_read),
       can_write_request_(can_write_request),
       can_write_command_(can_write_command),
       can_notify_(can_notify),
-      can_indicate_(can_indicate) {}
+      can_indicate_(can_indicate),
+      can_broadcast_(can_broadcast),
+      can_write_authenticated_signed_(can_write_authenticated_signed),
+      has_extended_properties_(has_extended_properties) {}
 
 BluetoothUUID CharacteristicBase::uuid() { return uuid_; }
 
@@ -26,3 +30,6 @@ bool CharacteristicBase::can_write_request() { return can_write_request_; }
 bool CharacteristicBase::can_write_command() { return can_write_command_; }
 bool CharacteristicBase::can_notify() { return can_notify_; }
 bool CharacteristicBase::can_indicate() { return can_indicate_; }
+bool CharacteristicBase::can_broadcast() { return can_broadcast_; }
+bool CharacteristicBase::can_write_authenticated_signed() { return can_write_authenticated_signed_; }
+bool CharacteristicBase::has_extended_properties() { return has_extended_properties_; }

--- a/simpleble/src/backends/common/CharacteristicBase.h
+++ b/simpleble/src/backends/common/CharacteristicBase.h
@@ -12,7 +12,8 @@ class CharacteristicBase {
   public:
     CharacteristicBase(const BluetoothUUID& uuid, std::vector<std::shared_ptr<DescriptorBase>> descriptors,
                        bool can_read, bool can_write_request, bool can_write_command, bool can_notify,
-                       bool can_indicate);
+                       bool can_indicate, bool can_broadcast, bool can_write_authenticated_signed,
+                       bool has_extended_properties);
     virtual ~CharacteristicBase() = default;
 
     BluetoothUUID uuid();
@@ -23,6 +24,9 @@ class CharacteristicBase {
     bool can_write_command();
     bool can_notify();
     bool can_indicate();
+    bool can_broadcast();
+    bool can_write_authenticated_signed();
+    bool has_extended_properties();
 
   protected:
     BluetoothUUID uuid_;
@@ -33,6 +37,9 @@ class CharacteristicBase {
     bool can_write_command_ = false;
     bool can_notify_ = false;
     bool can_indicate_ = false;
+    bool can_broadcast_ = false;
+    bool can_write_authenticated_signed_ = false;
+    bool has_extended_properties_ = false;
 };
 
 }  // namespace SimpleBLE

--- a/simpleble/src/backends/dongl/PeripheralDongl.cpp
+++ b/simpleble/src/backends/dongl/PeripheralDongl.cpp
@@ -113,7 +113,9 @@ SharedPtrVector<ServiceBase> PeripheralDongl::available_services() {
             }
             characteristic_list.push_back(std::make_shared<CharacteristicBase>(
                 characteristic.uuid, descriptor_list, characteristic.can_read, characteristic.can_write_request,
-                characteristic.can_write_command, characteristic.can_notify, characteristic.can_indicate));
+                characteristic.can_write_command, characteristic.can_notify, characteristic.can_indicate,
+                characteristic.can_broadcast, characteristic.can_write_authenticated_signed,
+                characteristic.has_extended_properties));
         }
         service_list.push_back(std::make_shared<ServiceBase>(service.uuid, characteristic_list));
     }
@@ -427,6 +429,9 @@ void PeripheralDongl::notify_characteristic_discovered(simpleble_CharacteristicD
         evt.props.write_wo_resp,
         evt.props.notify,
         evt.props.indicate,
+        evt.props.broadcast,
+        evt.props.auth_signed_wr,
+        false,
     });
 }
 

--- a/simpleble/src/backends/dongl/PeripheralDongl.h
+++ b/simpleble/src/backends/dongl/PeripheralDongl.h
@@ -92,6 +92,9 @@ class PeripheralDongl : public PeripheralBase {
         bool can_write_command;
         bool can_notify;
         bool can_indicate;
+        bool can_broadcast;
+        bool can_write_authenticated_signed;
+        bool has_extended_properties;
 
         std::vector<DescriptorDefinition> descriptors;
     };

--- a/simpleble/src/backends/linux/PeripheralLinux.cpp
+++ b/simpleble/src/backends/linux/PeripheralLinux.cpp
@@ -177,10 +177,14 @@ SharedPtrVector<ServiceBase> PeripheralLinux::available_services() {
             bool can_write_command = std::find(flags.begin(), flags.end(), "write-without-response") != flags.end();
             bool can_notify = std::find(flags.begin(), flags.end(), "notify") != flags.end();
             bool can_indicate = std::find(flags.begin(), flags.end(), "indicate") != flags.end();
+            bool can_broadcast = std::find(flags.begin(), flags.end(), "broadcast") != flags.end();
+            bool can_write_authenticated_signed = std::find(flags.begin(), flags.end(),
+                                                            "authenticated-signed-writes") != flags.end();
+            bool has_extended_properties = std::find(flags.begin(), flags.end(), "extended-properties") != flags.end();
 
-            characteristic_list.push_back(
-                std::make_shared<CharacteristicBase>(bluez_characteristic->uuid(), descriptor_list, can_read,
-                                                     can_write_request, can_write_command, can_notify, can_indicate));
+            characteristic_list.push_back(std::make_shared<CharacteristicBase>(
+                bluez_characteristic->uuid(), descriptor_list, can_read, can_write_request, can_write_command,
+                can_notify, can_indicate, can_broadcast, can_write_authenticated_signed, has_extended_properties));
         }
 
         service_list.push_back(std::make_shared<ServiceBase>(bluez_service->uuid(), characteristic_list));
@@ -191,7 +195,7 @@ SharedPtrVector<ServiceBase> PeripheralLinux::available_services() {
         // Emulate the battery service through the Battery1 interface.
         SharedPtrVector<DescriptorBase> descriptor_list;
         SharedPtrVector<CharacteristicBase> characteristic_list = {std::make_shared<CharacteristicBase>(
-            BATTERY_CHARACTERISTIC_UUID, descriptor_list, true, false, false, true, false)};
+            BATTERY_CHARACTERISTIC_UUID, descriptor_list, true, false, false, true, false, false, false, false)};
         service_list.push_back(std::make_shared<ServiceBase>(BATTERY_SERVICE_UUID, characteristic_list));
     }
 

--- a/simpleble/src/backends/linux_legacy/PeripheralLinuxLegacy.cpp
+++ b/simpleble/src/backends/linux_legacy/PeripheralLinuxLegacy.cpp
@@ -154,10 +154,14 @@ SharedPtrVector<ServiceBase> PeripheralLinuxLegacy::available_services() {
             bool can_write_command = std::find(flags.begin(), flags.end(), "write-without-response") != flags.end();
             bool can_notify = std::find(flags.begin(), flags.end(), "notify") != flags.end();
             bool can_indicate = std::find(flags.begin(), flags.end(), "indicate") != flags.end();
+            bool can_broadcast = std::find(flags.begin(), flags.end(), "broadcast") != flags.end();
+            bool can_write_authenticated_signed = std::find(flags.begin(), flags.end(),
+                                                            "authenticated-signed-writes") != flags.end();
+            bool has_extended_properties = std::find(flags.begin(), flags.end(), "extended-properties") != flags.end();
 
-            characteristic_list.push_back(
-                std::make_shared<CharacteristicBase>(bluez_characteristic->uuid(), descriptor_list, can_read,
-                                                     can_write_request, can_write_command, can_notify, can_indicate));
+            characteristic_list.push_back(std::make_shared<CharacteristicBase>(
+                bluez_characteristic->uuid(), descriptor_list, can_read, can_write_request, can_write_command,
+                can_notify, can_indicate, can_broadcast, can_write_authenticated_signed, has_extended_properties));
         }
 
         service_list.push_back(std::make_shared<ServiceBase>(bluez_service->uuid(), characteristic_list));
@@ -168,7 +172,7 @@ SharedPtrVector<ServiceBase> PeripheralLinuxLegacy::available_services() {
         // Emulate the battery service through the Battery1 interface.
         SharedPtrVector<DescriptorBase> descriptor_list;
         SharedPtrVector<CharacteristicBase> characteristic_list = {std::make_shared<CharacteristicBase>(
-            BATTERY_CHARACTERISTIC_UUID, descriptor_list, true, false, false, true, false)};
+            BATTERY_CHARACTERISTIC_UUID, descriptor_list, true, false, false, true, false, false, false, false)};
         service_list.push_back(std::make_shared<ServiceBase>(BATTERY_SERVICE_UUID, characteristic_list));
     }
 

--- a/simpleble/src/backends/macos/PeripheralBaseMacOS.mm
+++ b/simpleble/src/backends/macos/PeripheralBaseMacOS.mm
@@ -308,10 +308,17 @@ static SimpleBLE::ByteArray descriptorValueToByteArray(id value) {
             bool can_write_command = (characteristic.properties & CBCharacteristicPropertyWriteWithoutResponse) != 0;
             bool can_notify = (characteristic.properties & CBCharacteristicPropertyNotify) != 0;
             bool can_indicate = (characteristic.properties & CBCharacteristicPropertyIndicate) != 0;
+            bool can_broadcast = (characteristic.properties & CBCharacteristicPropertyBroadcast) != 0;
+            bool can_write_authenticated_signed =
+                (characteristic.properties & CBCharacteristicPropertyAuthenticatedSignedWrites) != 0;
+            bool has_extended_properties =
+                (characteristic.properties & CBCharacteristicPropertyExtendedProperties) != 0;
 
             characteristic_list.push_back(std::make_shared<SimpleBLE::CharacteristicBase>(uuidToSimpleBLE(characteristic.UUID),
                                                                                           descriptor_list, can_read, can_write_request,
-                                                                                          can_write_command, can_notify, can_indicate));
+                                                                                          can_write_command, can_notify, can_indicate,
+                                                                                          can_broadcast, can_write_authenticated_signed,
+                                                                                          has_extended_properties));
         }
         service_list.push_back(std::make_shared<SimpleBLE::ServiceBase>(uuidToSimpleBLE(service.UUID), characteristic_list));
     }

--- a/simpleble/src/backends/plain/PeripheralPlain.cpp
+++ b/simpleble/src/backends/plain/PeripheralPlain.cpp
@@ -65,7 +65,7 @@ SharedPtrVector<ServiceBase> PeripheralPlain::available_services() {
     SharedPtrVector<ServiceBase> service_list;
     SharedPtrVector<DescriptorBase> descriptor_list;
     SharedPtrVector<CharacteristicBase> characteristic_list = {std::make_shared<CharacteristicBase>(
-        BATTERY_CHARACTERISTIC_UUID, descriptor_list, true, false, false, true, false)};
+        BATTERY_CHARACTERISTIC_UUID, descriptor_list, true, false, false, true, false, false, false, false)};
 
     service_list.push_back(std::make_shared<ServiceBase>(BATTERY_SERVICE_UUID, characteristic_list));
     return service_list;

--- a/simpleble/src/backends/windows/PeripheralWindows.cpp
+++ b/simpleble/src/backends/windows/PeripheralWindows.cpp
@@ -277,10 +277,15 @@ SharedPtrVector<ServiceBase> PeripheralWindows::available_services() {
             bool can_write_command = (properties & (uint32_t)GattCharacteristicProperties::WriteWithoutResponse) != 0;
             bool can_notify = (properties & (uint32_t)GattCharacteristicProperties::Notify) != 0;
             bool can_indicate = (properties & (uint32_t)GattCharacteristicProperties::Indicate) != 0;
+            bool can_broadcast = (properties & (uint32_t)GattCharacteristicProperties::Broadcast) != 0;
+            bool can_write_authenticated_signed =
+                (properties & (uint32_t)GattCharacteristicProperties::AuthenticatedSignedWrites) != 0;
+            bool has_extended_properties = (properties & (uint32_t)GattCharacteristicProperties::ExtendedProperties) !=
+                                           0;
 
-            characteristic_list.push_back(
-                std::make_shared<CharacteristicBase>(characteristic_uuid, descriptor_list, can_read, can_write_request,
-                                                     can_write_command, can_notify, can_indicate));
+            characteristic_list.push_back(std::make_shared<CharacteristicBase>(
+                characteristic_uuid, descriptor_list, can_read, can_write_request, can_write_command, can_notify,
+                can_indicate, can_broadcast, can_write_authenticated_signed, has_extended_properties));
         }
         service_list.push_back(std::make_shared<ServiceBase>(service_uuid, characteristic_list));
     }

--- a/simpleble/src/frontends/base/Characteristic.cpp
+++ b/simpleble/src/frontends/base/Characteristic.cpp
@@ -32,6 +32,18 @@ std::vector<std::string> Characteristic::capabilities() {
         capabilities.push_back("indicate");
     }
 
+    if (can_broadcast()) {
+        capabilities.push_back("broadcast");
+    }
+
+    if (can_write_authenticated_signed()) {
+        capabilities.push_back("authenticated_signed_writes");
+    }
+
+    if (has_extended_properties()) {
+        capabilities.push_back("extended_properties");
+    }
+
     return capabilities;
 }
 
@@ -54,3 +66,6 @@ bool Characteristic::can_write_request() { return (*this)->can_write_request(); 
 bool Characteristic::can_write_command() { return (*this)->can_write_command(); }
 bool Characteristic::can_notify() { return (*this)->can_notify(); }
 bool Characteristic::can_indicate() { return (*this)->can_indicate(); }
+bool Characteristic::can_broadcast() { return (*this)->can_broadcast(); }
+bool Characteristic::can_write_authenticated_signed() { return (*this)->can_write_authenticated_signed(); }
+bool Characteristic::has_extended_properties() { return (*this)->has_extended_properties(); }

--- a/simpleble/test/src/test_characteristic.cpp
+++ b/simpleble/test/src/test_characteristic.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include <simpleble/Characteristic.h>
+
+#include "backends/common/CharacteristicBase.h"
+
+namespace {
+
+class TestCharacteristic : public SimpleBLE::Characteristic {
+  public:
+    TestCharacteristic(bool can_broadcast, bool can_write_authenticated_signed, bool has_extended_properties) {
+        internal_ = std::make_shared<SimpleBLE::CharacteristicBase>(
+            "00002A00-0000-1000-8000-00805F9B34FB", std::vector<std::shared_ptr<SimpleBLE::DescriptorBase>>{}, false,
+            false, false, false, false, can_broadcast, can_write_authenticated_signed, has_extended_properties);
+    }
+};
+
+TEST(CharacteristicTest, AdditionalPropertyAccessorsAndCapabilities) {
+    TestCharacteristic characteristic(true, true, true);
+
+    EXPECT_TRUE(characteristic.can_broadcast());
+    EXPECT_TRUE(characteristic.can_write_authenticated_signed());
+    EXPECT_TRUE(characteristic.has_extended_properties());
+    EXPECT_EQ(characteristic.capabilities(),
+              std::vector<std::string>({"broadcast", "authenticated_signed_writes", "extended_properties"}));
+}
+
+TEST(CharacteristicTest, AdditionalCapabilitiesAreOmittedWhenUnsupported) {
+    TestCharacteristic characteristic(false, false, false);
+
+    EXPECT_FALSE(characteristic.can_broadcast());
+    EXPECT_FALSE(characteristic.can_write_authenticated_signed());
+    EXPECT_FALSE(characteristic.has_extended_properties());
+    EXPECT_TRUE(characteristic.capabilities().empty());
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

- I added C++ accessors for broadcast, authenticated signed writes, and extended properties.
- I mapped the native property flags across BlueZ, legacy Linux, Android, macOS, Windows, and Dongl while keeping plain/emulated characteristics explicit.
- I added regression coverage for the new accessors and capability strings.

## Validation

- Configured and built the SimpleBLE plain backend with tests enabled.
- `simpleble_test --gtest_filter='CharacteristicTest.*'` (2 passed)
- Complete `simpleble_test` suite (35 passed)
- clang-format 18 changed-line check
- `git diff --check upstream/main...HEAD`

The full Windows, macOS, Android, and cross-platform build matrix is deferred to CI because those platform toolchains are not available on this Linux host.

Fixes #486
