### PR TITLE
Add Windows peripheral mode

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -192,6 +192,12 @@ include simpleble/src/backends/windows/AdapterWindows.cpp
 include simpleble/src/backends/windows/AdapterWindows.h
 include simpleble/src/backends/windows/BackendWinRT.cpp
 include simpleble/src/backends/windows/BackendWinRT.h
+include simpleble/src/backends/windows/LocalCharacteristicWindows.cpp
+include simpleble/src/backends/windows/LocalCharacteristicWindows.h
+include simpleble/src/backends/windows/LocalPeripheralWindows.cpp
+include simpleble/src/backends/windows/LocalPeripheralWindows.h
+include simpleble/src/backends/windows/LocalServiceWindows.cpp
+include simpleble/src/backends/windows/LocalServiceWindows.h
 include simpleble/src/backends/windows/MtaManager.cpp
 include simpleble/src/backends/windows/MtaManager.h
 include simpleble/src/backends/windows/PeripheralWindows.cpp

--- a/docs/content/docs/changelog.mdx
+++ b/docs/content/docs/changelog.mdx
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - (SimpleBluez) Added device connection-state change callbacks.
 - (Linux) Added local peripheral-mode support.
 - (MacOS) Added local peripheral-mode support.
-- (Windows) Added initial local peripheral-mode support through WinRT.
+- (Windows) Added local peripheral-mode support.
 - (SimpleBLE) Added initial local peripheral-mode API scaffolding.
 
 **Changed**

--- a/docs/content/docs/changelog.mdx
+++ b/docs/content/docs/changelog.mdx
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - (SimpleBluez) Added device connection-state change callbacks.
 - (Linux) Added local peripheral-mode support.
 - (MacOS) Added local peripheral-mode support.
+- (Windows) Added initial local peripheral-mode support through WinRT.
 - (SimpleBLE) Added initial local peripheral-mode API scaffolding.
 
 **Changed**

--- a/docs/content/docs/fundamentals/ble_basics.mdx
+++ b/docs/content/docs/fundamentals/ble_basics.mdx
@@ -12,7 +12,7 @@ In BLE, there are two primary roles when two devices are communicating:
 *   **Central:** Typically a smartphone or computer (like the one running SimpleBLE). The Central scans for advertisements and initiates connections.
 *   **Peripheral:** Typically a small, low-power device (like a heart rate monitor or a smart bulb). The Peripheral advertises its presence and waits for a Central to connect.
 
-SimpleBLE can fill either role. Central APIs (`SimpleBLE::Adapter` scan and `SimpleBLE::Peripheral`) are available on every supported platform. Hosting a local peripheral (`SimpleBLE::Local::Peripheral`) is currently available through the C++ API on Linux and macOS; see [Advertise, Serve, Publish](../simpleble/peripheral/advertise-serve-publish).
+SimpleBLE can fill either role. Central APIs (`SimpleBLE::Adapter` scan and `SimpleBLE::Peripheral`) are available on every supported platform. Hosting a local peripheral (`SimpleBLE::Local::Peripheral`) is currently available through the C++ API on Linux, macOS, and Windows; see [Advertise, Serve, Publish](../simpleble/peripheral/advertise-serve-publish).
 
 ## Advertising and Scanning
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -5,7 +5,7 @@ description: Get to a first successful BLE scan with SimpleBLE in your language.
 
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 
-This quickstart gets you to the first adoption milestone: your application can see nearby BLE devices. After that, move to the [Connect](./recipes/connect) and [Read, Write, Notify](./recipes/read-write-notify) recipes, or [Advertise](./recipes/advertise) to host a local peripheral on Linux or macOS.
+This quickstart gets you to the first adoption milestone: your application can see nearby BLE devices. After that, move to the [Connect](./recipes/connect) and [Read, Write, Notify](./recipes/read-write-notify) recipes, or [Advertise](./recipes/advertise) to host a local peripheral on Linux, macOS, or Windows.
 
 ## Before you run
 

--- a/docs/content/docs/recipes/advertise.mdx
+++ b/docs/content/docs/recipes/advertise.mdx
@@ -9,8 +9,8 @@ Advertising is how this host is found. A local peripheral serves GATT, sends adv
 
 `SimpleBLE::Peripheral` is a remote device. `SimpleBLE::Local::Peripheral` is this host. Create the local peripheral from an `Adapter`, the same object used to scan.
 
-<Callout type="info" title="Linux/macOS, C++ only">
-Hosting a local peripheral is currently implemented on Linux and macOS. On other platforms, `create_local_peripheral()` throws `SimpleBLE::Exception::OperationNotSupported`. Other language bindings do not expose this API yet.
+<Callout type="info" title="Linux, macOS, or Windows; C++ only">
+Hosting a local peripheral is currently implemented on Linux, macOS, and Windows. On other platforms, `create_local_peripheral()` throws `SimpleBLE::Exception::OperationNotSupported`. Other language bindings do not expose this API yet.
 </Callout>
 
 ## Flow
@@ -56,7 +56,7 @@ peripheral.start();
 
 Configure services, characteristics, and advertising before `start()`. While started, update data with `set_value()` rather than rebuilding the GATT table. `set_value()` also publishes the latest value to subscribed clients when the characteristic has `NOTIFY` or `INDICATE` capability.
 
-Concurrent scanning and advertising depend on the platform Bluetooth stack and controller. On Linux, BlueZ and the controller must support both operations at the same time.
+SimpleBLE permits the same adapter to scan while the local peripheral is started when the platform Bluetooth stack and controller support concurrent scanning and advertising. On Linux, BlueZ and the controller must support both operations at the same time.
 
 ## Practical notes
 
@@ -64,5 +64,6 @@ Concurrent scanning and advertising depend on the platform Bluetooth stack and c
 - Pass capabilities as a `std::set` (an initializer list is enough). Each characteristic needs at least one capability.
 - On Linux, BlueZ must be running and the process must have D-Bus access, as with scanning.
 - On macOS, CoreBluetooth reports client connection and disconnection callbacks when the client first subscribes and finally unsubscribes.
+- On Windows, the adapter and driver must support the peripheral role. Packaged applications must declare the `bluetooth` device capability, and the system Bluetooth name is used instead of `advertisement.local_name`.
 
 For the full C++ walkthrough, see [Advertise, Serve, Publish](../simpleble/peripheral/advertise-serve-publish). For scanning from the other side of the link, see [Scan](./scan).

--- a/docs/content/docs/recipes/advertise.mdx
+++ b/docs/content/docs/recipes/advertise.mdx
@@ -64,6 +64,6 @@ SimpleBLE permits the same adapter to scan while the local peripheral is started
 - Pass capabilities as a `std::set` (an initializer list is enough). Each characteristic needs at least one capability.
 - On Linux, BlueZ must be running and the process must have D-Bus access, as with scanning.
 - On macOS, CoreBluetooth reports client connection and disconnection callbacks when the client first subscribes and finally unsubscribes.
-- On Windows, the adapter and driver must support the peripheral role. Packaged applications must declare the `bluetooth` device capability, and the system Bluetooth name is used instead of `advertisement.local_name`.
+- On Windows, the adapter and driver must support the peripheral role. Applications distributed as AppX/MSIX packages should declare `<DeviceCapability Name="bluetooth" />` in `Package.appxmanifest`; ordinary unpackaged executables do not need this manifest declaration. Windows uses the system Bluetooth name instead of `advertisement.local_name`.
 
 For the full C++ walkthrough, see [Advertise, Serve, Publish](../simpleble/peripheral/advertise-serve-publish). For scanning from the other side of the link, see [Scan](./scan).

--- a/docs/content/docs/simpleble/examples.mdx
+++ b/docs/content/docs/simpleble/examples.mdx
@@ -44,6 +44,6 @@ This example demonstrates how to subscribe to notifications on a characteristic 
 ### Peripheral
 [peripheral](https://github.com/simpleble/simpleble/blob/main/examples/simpleble/src/peripheral.cpp)
 
-This example hosts a local BLE peripheral on Linux or Windows: it advertises a custom service, accepts reads and writes, publishes notifications, and prints client connect, disconnect, and subscribe events.
+This example hosts a local BLE peripheral on Linux, macOS, or Windows: it advertises a custom service, accepts reads and writes, publishes notifications, and prints client connect, disconnect, and subscribe events.
 
 See [Advertise, Serve, Publish](./peripheral/advertise-serve-publish) for the matching walkthrough.

--- a/docs/content/docs/simpleble/examples.mdx
+++ b/docs/content/docs/simpleble/examples.mdx
@@ -44,6 +44,6 @@ This example demonstrates how to subscribe to notifications on a characteristic 
 ### Peripheral
 [peripheral](https://github.com/simpleble/simpleble/blob/main/examples/simpleble/src/peripheral.cpp)
 
-This example hosts a local BLE peripheral on Linux: it advertises a custom service, accepts reads and writes, publishes notifications, and prints client connect, disconnect, and subscribe events.
+This example hosts a local BLE peripheral on Linux or Windows: it advertises a custom service, accepts reads and writes, publishes notifications, and prints client connect, disconnect, and subscribe events.
 
 See [Advertise, Serve, Publish](./peripheral/advertise-serve-publish) for the matching walkthrough.

--- a/docs/content/docs/simpleble/faq.mdx
+++ b/docs/content/docs/simpleble/faq.mdx
@@ -13,7 +13,7 @@ Right now, the best way to have your questions answered is on our [Discord](http
 
 SimpleBLE supports Windows 10+, Linux (Ubuntu 20.04+ and other distros using Bluez), MacOS 13.0+ (Ventura and newer), iOS 15.0+, and Android API 31+.
 
-Central-role APIs (scan, connect, GATT client) are available on all of those platforms. Hosting a local peripheral is currently available through the C++ API on Linux and macOS.
+Central-role APIs (scan, connect, GATT client) are available on all of those platforms. Hosting a local peripheral is currently available through the C++ API on Linux, macOS, and Windows.
 
 Please check the overview page on more information about platform-specific limitations.
 
@@ -27,9 +27,9 @@ All configuration values must be set prior to any other interaction with a Simpl
 
 <Accordion title="Can I advertise and act as a BLE peripheral?" id="peripheral-mode">
 
-Yes, on Linux and macOS with the C++ API. Call `Adapter::create_local_peripheral()` to get a `SimpleBLE::Local::Peripheral`, configure services and advertising, then `start()`. See [Advertise, Serve, Publish](./peripheral/advertise-serve-publish) and the [Advertise](../recipes/advertise) recipe.
+Yes, on Linux, macOS, and Windows with the C++ API. Call `Adapter::create_local_peripheral()` to get a `SimpleBLE::Local::Peripheral`, configure services and advertising, then `start()`. See [Advertise, Serve, Publish](./peripheral/advertise-serve-publish) and the [Advertise](../recipes/advertise) recipe.
 
-On other platforms, `create_local_peripheral()` throws `SimpleBLE::Exception::OperationNotSupported`. Other language bindings do not expose this API yet.
+On Windows, peripheral mode requires adapter and driver support; WinRT uses the system Bluetooth name in discoverable advertisements. Packaged applications must also declare the `bluetooth` device capability. On unsupported platforms, `create_local_peripheral()` throws `SimpleBLE::Exception::OperationNotSupported`. Other language bindings do not expose this API yet.
 
 </Accordion>
 

--- a/docs/content/docs/simpleble/faq.mdx
+++ b/docs/content/docs/simpleble/faq.mdx
@@ -29,7 +29,7 @@ All configuration values must be set prior to any other interaction with a Simpl
 
 Yes, on Linux, macOS, and Windows with the C++ API. Call `Adapter::create_local_peripheral()` to get a `SimpleBLE::Local::Peripheral`, configure services and advertising, then `start()`. See [Advertise, Serve, Publish](./peripheral/advertise-serve-publish) and the [Advertise](../recipes/advertise) recipe.
 
-On Windows, peripheral mode requires adapter and driver support; WinRT uses the system Bluetooth name in discoverable advertisements. Packaged applications must also declare the `bluetooth` device capability. On unsupported platforms, `create_local_peripheral()` throws `SimpleBLE::Exception::OperationNotSupported`. Other language bindings do not expose this API yet.
+On Windows, peripheral mode requires adapter and driver support; WinRT uses the system Bluetooth name in discoverable advertisements. Applications distributed as AppX/MSIX packages should declare `<DeviceCapability Name="bluetooth" />` in `Package.appxmanifest`; ordinary unpackaged executables do not need this manifest declaration. On unsupported platforms, `create_local_peripheral()` throws `SimpleBLE::Exception::OperationNotSupported`. Other language bindings do not expose this API yet.
 
 </Accordion>
 

--- a/docs/content/docs/simpleble/peripheral/advertise-serve-publish.mdx
+++ b/docs/content/docs/simpleble/peripheral/advertise-serve-publish.mdx
@@ -9,8 +9,8 @@ This is the peripheral-mode walkthrough: this host advertises, serves a GATT tab
 
 `SimpleBLE::Peripheral` is a remote device discovered while acting as a central. `SimpleBLE::Local::Peripheral` is this host. Create the local peripheral from the same `Adapter` you would use to scan.
 
-<Callout type="info" title="Linux/macOS, C++ only">
-Hosting a local peripheral is currently implemented on Linux and macOS. On other platforms, `Adapter::create_local_peripheral()` throws `SimpleBLE::Exception::OperationNotSupported`.
+<Callout type="info" title="Linux, macOS, or Windows; C++ only">
+Hosting a local peripheral is currently implemented on Linux, macOS, and Windows. On other platforms, `Adapter::create_local_peripheral()` throws `SimpleBLE::Exception::OperationNotSupported`.
 </Callout>
 
 If you still need to install SimpleBLE or create the CMake project, start with [Getting Started](../tutorial). The [Advertise](../../recipes/advertise) recipe is the short form of this flow.
@@ -61,6 +61,8 @@ peripheral.set_advertisement(advertisement);
 ```
 
 If `service_uuids` is left empty, SimpleBLE advertises the service UUIDs configured on the local peripheral when the platform supports doing so.
+
+On Windows, WinRT uses the system Bluetooth name instead of `local_name`.
 
 ## Services and characteristics
 
@@ -135,11 +137,13 @@ On platforms that do not expose a Bluetooth address, the value is a platform-spe
 
 CoreBluetooth does not expose peripheral-role connection events on macOS. SimpleBLE reports a client as connected when it first subscribes to a characteristic and disconnected when its final subscription ends.
 
+On Windows, WinRT exposes the client session after a client first reads, writes, or subscribes to a hosted characteristic. A connection that performs no GATT operation may not produce a client-connected callback.
+
 Callbacks follow the same threading rules as the rest of SimpleBLE. See [Concurrency](../../fundamentals/concurrency).
 
 ## Scan and advertise together
 
-Concurrent scanning and advertising depend on the platform Bluetooth stack and controller. On Linux, BlueZ and the controller must support both operations at the same time. Incoming clients of the local peripheral are reported through the client callbacks above. They are not devices you should `connect()` to as a central.
+SimpleBLE permits the same adapter to scan while a local peripheral is started when the platform Bluetooth stack and controller support concurrent scanning and advertising. On Linux, BlueZ and the controller must support both operations at the same time. Incoming clients of the local peripheral are reported through the client callbacks above. They are not devices you should `connect()` to as a central.
 
 ## Full application
 
@@ -199,7 +203,7 @@ int main() {
         [](SimpleBLE::BluetoothAddress address) { std::cout << "Client connected: " << address << std::endl; });
 
     peripheral.start();
-    std::cout << "Advertising as SimpleBLE Peripheral. Press Ctrl+C to stop." << std::endl;
+    std::cout << "Local peripheral is advertising. Press Ctrl+C to stop." << std::endl;
 
     while (running) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -223,5 +227,5 @@ cmake --build build_simpleble_examples -j7
 - [Advertise](../../recipes/advertise) for a shorter recipe form of this flow
 - [Scan, Connect, Read](../central/scan-connect-read) to use the same adapter as a central
 - [API reference](../api#local-api) for `SimpleBLE::Local` types
-- [Platform notes](../platform_notes) for Linux and macOS behavior
+- [Platform notes](../platform_notes) for Linux, macOS, and Windows behavior
 - [Examples](../examples) for the programs in the repository

--- a/docs/content/docs/simpleble/platform_notes.mdx
+++ b/docs/content/docs/simpleble/platform_notes.mdx
@@ -14,7 +14,7 @@ If you are running a 32-bit application on a 64-bit Windows machine, you might e
 The Windows implementation currently has a limitation where `initialized()` might return true if *any* adapter is enabled, not necessarily the specific instance you are inspecting. This is a known issue being tracked.
 
 ### Local Peripheral Mode
-Windows hosts local services with WinRT `GattServiceProvider`. The Bluetooth adapter and driver must report peripheral-role support. Packaged applications must declare the `bluetooth` device capability in `Package.appxmanifest`, as required by WinRT.
+Windows hosts local services with WinRT `GattServiceProvider`. The Bluetooth adapter and driver must report peripheral-role support. Applications distributed as AppX/MSIX packages should declare `<DeviceCapability Name="bluetooth" />` in `Package.appxmanifest`; ordinary unpackaged executables do not need this manifest declaration.
 
 Windows controls the friendly name placed in a discoverable advertisement, so `Advertisement::local_name` cannot override the system Bluetooth name. WinRT requires one provider per primary service; SimpleBLE starts every configured provider as one peripheral operation and prioritizes providers listed in `Advertisement::service_uuids`. Windows owns the shared advertisement payload and may omit UUIDs that do not fit. Explicitly selected UUIDs must belong to configured services, and `start()` throws if the adapter or driver lacks the resources to publish every provider. Windows reports a client session after the client first interacts with or subscribes to a hosted characteristic; a bare link that performs no GATT operation may not produce a client-connected callback.
 

--- a/docs/content/docs/simpleble/platform_notes.mdx
+++ b/docs/content/docs/simpleble/platform_notes.mdx
@@ -13,6 +13,11 @@ If you are running a 32-bit application on a 64-bit Windows machine, you might e
 ### Adapter Selection
 The Windows implementation currently has a limitation where `initialized()` might return true if *any* adapter is enabled, not necessarily the specific instance you are inspecting. This is a known issue being tracked.
 
+### Local Peripheral Mode
+Windows hosts local services with WinRT `GattServiceProvider`. The Bluetooth adapter and driver must report peripheral-role support. Packaged applications must declare the `bluetooth` device capability in `Package.appxmanifest`, as required by WinRT.
+
+Windows controls the friendly name placed in a discoverable advertisement, so `Advertisement::local_name` cannot override the system Bluetooth name. WinRT requires one provider per primary service; SimpleBLE starts every configured provider as one peripheral operation and prioritizes providers listed in `Advertisement::service_uuids`. Windows owns the shared advertisement payload and may omit UUIDs that do not fit. Explicitly selected UUIDs must belong to configured services, and `start()` throws if the adapter or driver lacks the resources to publish every provider. Windows reports a client session after the client first interacts with or subscribes to a hosted characteristic; a bare link that performs no GATT operation may not produce a client-connected callback.
+
 ## MacOS / iOS
 
 ### Peripheral Identifiers (UUIDs)
@@ -63,7 +68,7 @@ On Linux, `Adapter::create_local_peripheral()` registers a BlueZ GATT applicatio
 
 SimpleBLE permits the same adapter to scan and advertise at the same time, but availability depends on BlueZ and the Bluetooth controller supporting concurrent operation and having sufficient resources. Incoming clients of the local peripheral are reported through `SimpleBLE::Local::Peripheral` client callbacks, not as remote `SimpleBLE::Peripheral` objects to `connect()` to.
 
-Local peripheral mode is currently available through the C++ API on Linux and macOS. Other platforms throw `SimpleBLE::Exception::OperationNotSupported`.
+Local peripheral mode is currently available through the C++ API on Linux, macOS, and Windows. Unsupported platforms throw `SimpleBLE::Exception::OperationNotSupported`.
 
 ## Android
 

--- a/docs/content/docs/simpleble/tutorial.mdx
+++ b/docs/content/docs/simpleble/tutorial.mdx
@@ -125,8 +125,8 @@ adapter.scan_for(5000);
 
 ## Act as a peripheral
 
-<Callout type="info" title="Linux/macOS, C++ only">
-Hosting a local peripheral is currently implemented on Linux and macOS. On other platforms, `create_local_peripheral()` throws `SimpleBLE::Exception::OperationNotSupported`.
+<Callout type="info" title="Linux, macOS, or Windows; C++ only">
+Hosting a local peripheral is currently implemented on Linux, macOS, and Windows. On other platforms, `create_local_peripheral()` throws `SimpleBLE::Exception::OperationNotSupported`.
 </Callout>
 
 `SimpleBLE::Local::Peripheral` is **this host** advertising and serving GATT. Configure the advertisement and at least one characteristic, then call `start()`:
@@ -143,8 +143,10 @@ service.add_characteristic("12345678-1234-5678-1234-56789abcdef1",
                            {SimpleBLE::Local::CharacteristicCapability::READ});
 
 peripheral.start();
-std::cout << "Advertising as SimpleBLE Peripheral." << std::endl;
+std::cout << "Local peripheral is advertising." << std::endl;
 ```
+
+On Windows, WinRT uses the system Bluetooth name instead of `advertisement.local_name`.
 
 Keep the process alive after `start()`, then call `peripheral.stop()` when you are done. Writes, notifications, and client connection callbacks are covered in [Advertise, Serve, Publish](./peripheral/advertise-serve-publish).
 

--- a/simpleble/CMakeLists.txt
+++ b/simpleble/CMakeLists.txt
@@ -323,6 +323,9 @@ elseif(SIMPLEBLE_BACKEND_WINDOWS)
 
     target_sources(simpleble PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/backends/windows/AdapterWindows.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/backends/windows/LocalCharacteristicWindows.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/backends/windows/LocalPeripheralWindows.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/backends/windows/LocalServiceWindows.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/backends/windows/PeripheralWindows.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/backends/windows/BackendWinRT.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/backends/windows/MtaManager.cpp

--- a/simpleble/src/backends/windows/AdapterWindows.cpp
+++ b/simpleble/src/backends/windows/AdapterWindows.cpp
@@ -5,6 +5,7 @@
 
 #include "BuilderBase.h"
 #include "CommonUtils.h"
+#include "LocalPeripheralWindows.h"
 #include "LoggingInternal.h"
 #include "PeripheralWindows.h"
 #include "Utils.h"
@@ -163,6 +164,17 @@ SharedPtrVector<PeripheralBase> AdapterWindows::get_connected_peripherals() {
     const winrt::hstring aqs_filter =
         BluetoothLEDevice::GetDeviceSelectorFromConnectionStatus(BluetoothConnectionStatus::Connected);
     return _get_peripherals_from_selector(aqs_filter);
+}
+
+std::shared_ptr<Local::PeripheralBase> AdapterWindows::create_local_peripheral() {
+    return MtaManager::get().execute_sync<std::shared_ptr<Local::PeripheralBase>>([this]() {
+        if (!Foundation::Metadata::ApiInformation::IsPropertyPresent(
+                L"Windows.Devices.Bluetooth.BluetoothAdapter", L"IsPeripheralRoleSupported") ||
+            !adapter_.IsPeripheralRoleSupported()) {
+            throw Exception::OperationNotSupported();
+        }
+        return std::make_shared<Local::PeripheralWindows>(adapter_);
+    });
 }
 
 SharedPtrVector<PeripheralBase> AdapterWindows::_get_peripherals_from_selector(const winrt::hstring& aqs_filter) {

--- a/simpleble/src/backends/windows/AdapterWindows.h
+++ b/simpleble/src/backends/windows/AdapterWindows.h
@@ -28,6 +28,9 @@ namespace SimpleBLE {
 
 class PeripheralWindows;
 class PeripheralBase;
+namespace Local {
+class PeripheralBase;
+}
 
 class AdapterWindows : public AdapterBase {
   public:
@@ -51,6 +54,8 @@ class AdapterWindows : public AdapterBase {
 
     virtual std::vector<std::shared_ptr<PeripheralBase>> get_paired_peripherals() override;
     virtual std::vector<std::shared_ptr<PeripheralBase>> get_connected_peripherals() override;
+
+    virtual std::shared_ptr<Local::PeripheralBase> create_local_peripheral() override;
 
     virtual bool bluetooth_enabled() override;
 

--- a/simpleble/src/backends/windows/LocalCharacteristicWindows.cpp
+++ b/simpleble/src/backends/windows/LocalCharacteristicWindows.cpp
@@ -209,11 +209,7 @@ void CharacteristicWindows::reset_subscriptions() {
     std::scoped_lock lock(_subscription_mutex);
     _subscribed_clients = 0;
     _subscription_generation = 0;
-    _subscription_callback_delivered = false;
-    _subscription_callback_in_progress = false;
-    ++_subscription_transition_sequence;
-    _subscription_delivery_generation = 0;
-    _subscription_delivery_sequence = 0;
+    _subscription_callbacks_enabled = false;
 }
 
 void CharacteristicWindows::reconcile_subscriptions(uint64_t generation) noexcept {
@@ -223,22 +219,17 @@ void CharacteristicWindows::reconcile_subscriptions(uint64_t generation) noexcep
 }
 
 void CharacteristicWindows::enable_subscription_callbacks(uint64_t generation) {
-    uint64_t sequence = 0;
+    bool notify_subscribed = false;
     {
         std::scoped_lock lock(_subscription_mutex);
-        if (_subscription_generation == generation && _subscribed_clients > 0 && !_subscription_callback_delivered &&
-            _callback_observer && _callback_observer(generation)) {
-            ++_subscription_transition_sequence;
-            if (!_subscription_callback_in_progress) {
-                _subscription_callback_in_progress = true;
-                _subscription_delivery_generation = generation;
-                _subscription_delivery_sequence = _subscription_transition_sequence;
-                sequence = _subscription_delivery_sequence;
-            }
+        if (_subscription_generation == generation && !_subscription_callbacks_enabled && _callback_observer &&
+            _callback_observer(generation)) {
+            _subscription_callbacks_enabled = true;
+            notify_subscribed = _subscribed_clients > 0;
         }
     }
-    if (sequence != 0) {
-        _deliver_subscription_callback(generation, sequence, true);
+    if (notify_subscribed) {
+        SAFE_CALLBACK_CALL(_callback_on_subscribed);
     }
 }
 
@@ -391,8 +382,8 @@ void CharacteristicWindows::_on_subscribed_clients_changed(const GattLocalCharac
             }
         }
 
-        uint64_t delivery_sequence = 0;
-        bool delivery_state = false;
+        bool notify = false;
+        bool subscribed = false;
         {
             std::scoped_lock lock(_subscription_mutex);
             if (!_activity_observer || _activity_observer() != generation ||
@@ -400,26 +391,20 @@ void CharacteristicWindows::_on_subscribed_clients_changed(const GattLocalCharac
                 return;
             }
 
-            const bool previous_state = _subscription_generation == generation ? _subscribed_clients > 0 : false;
+            const bool was_subscribed = _subscription_generation == generation && _subscribed_clients > 0;
             _subscribed_clients = clients.Size();
             _subscription_generation = generation;
-            const bool current_state = _subscribed_clients > 0;
-            const bool callbacks_enabled = _callback_observer && _callback_observer(generation);
-            if (previous_state != current_state) {
-                ++_subscription_transition_sequence;
-            }
-            if (callbacks_enabled && current_state != _subscription_callback_delivered &&
-                !_subscription_callback_in_progress) {
-                _subscription_callback_in_progress = true;
-                _subscription_delivery_generation = generation;
-                _subscription_delivery_sequence = _subscription_transition_sequence;
-                delivery_sequence = _subscription_delivery_sequence;
-                delivery_state = current_state;
-            }
+            subscribed = _subscribed_clients > 0;
+            notify = _subscription_callbacks_enabled && _callback_observer && _callback_observer(generation) &&
+                     was_subscribed != subscribed;
         }
 
-        if (delivery_sequence != 0) {
-            _deliver_subscription_callback(generation, delivery_sequence, delivery_state);
+        if (notify) {
+            if (subscribed) {
+                SAFE_CALLBACK_CALL(_callback_on_subscribed);
+            } else {
+                SAFE_CALLBACK_CALL(_callback_on_unsubscribed);
+            }
         }
     } catch (const std::exception& ex) {
         SIMPLEBLE_LOG_ERROR(
@@ -427,48 +412,6 @@ void CharacteristicWindows::_on_subscribed_clients_changed(const GattLocalCharac
     } catch (...) {
         SIMPLEBLE_LOG_ERROR(
             fmt::format("Unknown exception while handling local characteristic {} subscriptions", _uuid));
-    }
-}
-
-void CharacteristicWindows::_deliver_subscription_callback(uint64_t generation, uint64_t sequence, bool subscribed) {
-    while (true) {
-        if (!_callback_observer || !_callback_observer(generation)) {
-            std::scoped_lock lock(_subscription_mutex);
-            if (_subscription_delivery_generation == generation && _subscription_delivery_sequence == sequence) {
-                _subscription_callback_in_progress = false;
-                _subscription_delivery_generation = 0;
-                _subscription_delivery_sequence = 0;
-            }
-            return;
-        }
-
-        if (subscribed) {
-            SAFE_CALLBACK_CALL(_callback_on_subscribed);
-        } else {
-            SAFE_CALLBACK_CALL(_callback_on_unsubscribed);
-        }
-
-        {
-            std::scoped_lock lock(_subscription_mutex);
-            if (_subscription_delivery_generation != generation || _subscription_delivery_sequence != sequence ||
-                _subscription_generation != generation) {
-                return;
-            }
-
-            _subscription_callback_delivered = subscribed;
-            const bool current_state = _subscribed_clients > 0;
-            if (current_state == _subscription_callback_delivered || !_callback_observer ||
-                !_callback_observer(generation)) {
-                _subscription_callback_in_progress = false;
-                _subscription_delivery_generation = 0;
-                _subscription_delivery_sequence = 0;
-                return;
-            }
-
-            sequence = _subscription_transition_sequence;
-            subscribed = current_state;
-            _subscription_delivery_sequence = sequence;
-        }
     }
 }
 

--- a/simpleble/src/backends/windows/LocalCharacteristicWindows.cpp
+++ b/simpleble/src/backends/windows/LocalCharacteristicWindows.cpp
@@ -226,8 +226,8 @@ void CharacteristicWindows::enable_subscription_callbacks(uint64_t generation) {
     uint64_t sequence = 0;
     {
         std::scoped_lock lock(_subscription_mutex);
-        if (_subscription_generation == generation && _subscribed_clients > 0 &&
-            !_subscription_callback_delivered && _callback_observer && _callback_observer(generation)) {
+        if (_subscription_generation == generation && _subscribed_clients > 0 && !_subscription_callback_delivered &&
+            _callback_observer && _callback_observer(generation)) {
             ++_subscription_transition_sequence;
             if (!_subscription_callback_in_progress) {
                 _subscription_callback_in_progress = true;
@@ -256,8 +256,15 @@ void CharacteristicWindows::_on_read_requested(const GattLocalCharacteristic&, c
             return;
         }
 
+        const uint64_t generation = _activity_observer ? _activity_observer() : 0;
+        if (generation == 0) {
+            request.RespondWithProtocolError(ATT_ERROR_UNLIKELY);
+            deferral.Complete();
+            return;
+        }
+
         ByteArray response;
-        if (_activity_observer && _activity_observer() != 0 && _callback_on_read) {
+        if (_activity_observer && _activity_observer() == generation && _callback_on_read) {
             response = _callback_on_read();
             std::scoped_lock lock(_value_mutex);
             _value = response;
@@ -310,6 +317,14 @@ void CharacteristicWindows::_on_write_requested(const GattLocalCharacteristic&,
         }
 
         should_respond = request.Option() == GattWriteOption::WriteWithResponse;
+        const uint64_t generation = _activity_observer ? _activity_observer() : 0;
+        if (generation == 0) {
+            if (should_respond) {
+                request.RespondWithProtocolError(ATT_ERROR_UNLIKELY);
+            }
+            deferral.Complete();
+            return;
+        }
         const ByteArray incoming = ibuffer_to_bytearray(request.Value());
         const size_t offset = request.Offset();
         ByteArray updated;
@@ -333,7 +348,7 @@ void CharacteristicWindows::_on_write_requested(const GattLocalCharacteristic&,
             _value = updated;
         }
 
-        if (_activity_observer && _activity_observer() != 0) {
+        if (_activity_observer && _activity_observer() == generation) {
             SAFE_CALLBACK_CALL(_callback_on_write, updated);
         }
         if (should_respond) {
@@ -385,8 +400,7 @@ void CharacteristicWindows::_on_subscribed_clients_changed(const GattLocalCharac
                 return;
             }
 
-            const bool previous_state =
-                _subscription_generation == generation ? _subscribed_clients > 0 : false;
+            const bool previous_state = _subscription_generation == generation ? _subscribed_clients > 0 : false;
             _subscribed_clients = clients.Size();
             _subscription_generation = generation;
             const bool current_state = _subscribed_clients > 0;

--- a/simpleble/src/backends/windows/LocalCharacteristicWindows.cpp
+++ b/simpleble/src/backends/windows/LocalCharacteristicWindows.cpp
@@ -228,7 +228,7 @@ void CharacteristicWindows::enable_subscription_callbacks(uint64_t generation) {
             notify_subscribed = _subscribed_clients > 0;
         }
     }
-    if (notify_subscribed) {
+    if (notify_subscribed && _callback_observer && _callback_observer(generation)) {
         SAFE_CALLBACK_CALL(_callback_on_subscribed);
     }
 }
@@ -399,7 +399,7 @@ void CharacteristicWindows::_on_subscribed_clients_changed(const GattLocalCharac
                      was_subscribed != subscribed;
         }
 
-        if (notify) {
+        if (notify && _callback_observer && _callback_observer(generation)) {
             if (subscribed) {
                 SAFE_CALLBACK_CALL(_callback_on_subscribed);
             } else {

--- a/simpleble/src/backends/windows/LocalCharacteristicWindows.cpp
+++ b/simpleble/src/backends/windows/LocalCharacteristicWindows.cpp
@@ -58,12 +58,12 @@ CharacteristicWindows::~CharacteristicWindows() {
     _callback_on_write.unload();
     _callback_on_subscribed.unload();
     _callback_on_unsubscribed.unload();
-    stop_native();
+    destroy_native();
 }
 
-void CharacteristicWindows::start_native(const GattLocalService& service, SessionObserver session_observer,
-                                         ActivityObserver activity_observer) {
-    stop_native();
+void CharacteristicWindows::create_native(const GattLocalService& service, SessionObserver session_observer,
+                                          std::shared_ptr<std::atomic_bool> active) {
+    destroy_native();
 
     auto parameters = GattLocalCharacteristicParameters();
     parameters.CharacteristicProperties(properties_from_capabilities(_capabilities));
@@ -85,7 +85,7 @@ void CharacteristicWindows::start_native(const GattLocalService& service, Sessio
     auto native = std::make_shared<NativeState>();
     native->characteristic = result.Characteristic();
     native->session_observer = std::move(session_observer);
-    native->activity_observer = std::move(activity_observer);
+    native->active = std::move(active);
 
     auto weak_self = weak_from_this();
     std::weak_ptr<NativeState> weak_native = native;
@@ -123,7 +123,7 @@ void CharacteristicWindows::start_native(const GattLocalService& service, Sessio
     _native = std::move(native);
 }
 
-void CharacteristicWindows::stop_native() noexcept {
+void CharacteristicWindows::destroy_native() noexcept {
     std::shared_ptr<NativeState> native;
     {
         std::scoped_lock lock(_native_mutex);
@@ -151,14 +151,14 @@ void CharacteristicWindows::set_value(ByteArray value) {
 
     const bool can_publish = _capabilities.count(CharacteristicCapability::NOTIFY) != 0 ||
                              _capabilities.count(CharacteristicCapability::INDICATE) != 0;
-    const auto native = _native_snapshot();
-    if (!can_publish || !native || !native->subscribed.load() || !native->active()) {
+    const auto native = _native_state();
+    if (!can_publish || !native || !native->subscribed.load() || !native->is_active()) {
         return;
     }
 
     try {
         WinRT::MtaManager::get().execute_sync([native, value_snapshot]() {
-            if (native->active()) {
+            if (native->is_active()) {
                 async_get(native->characteristic.NotifyValueAsync(bytearray_to_ibuffer(value_snapshot)));
             }
         });
@@ -199,7 +199,7 @@ void CharacteristicWindows::set_callback_on_unsubscribed(std::function<void()> o
     }
 }
 
-std::shared_ptr<CharacteristicWindows::NativeState> CharacteristicWindows::_native_snapshot() {
+std::shared_ptr<CharacteristicWindows::NativeState> CharacteristicWindows::_native_state() {
     std::scoped_lock lock(_native_mutex);
     return _native;
 }
@@ -233,7 +233,7 @@ void CharacteristicWindows::_on_read_requested(const std::shared_ptr<NativeState
     auto deferral = args.GetDeferral();
     GattReadRequest request{nullptr};
     try {
-        if (!native->active()) {
+        if (!native->is_active()) {
             deferral.Complete();
             return;
         }
@@ -246,14 +246,14 @@ void CharacteristicWindows::_on_read_requested(const std::shared_ptr<NativeState
             deferral.Complete();
             return;
         }
-        if (!native->active()) {
+        if (!native->is_active()) {
             request.RespondWithProtocolError(ATT_ERROR_UNLIKELY);
             deferral.Complete();
             return;
         }
 
         ByteArray response;
-        if (_callback_on_read && native->active()) {
+        if (_callback_on_read && native->is_active()) {
             response = _callback_on_read();
             std::scoped_lock lock(_value_mutex);
             _value = response;
@@ -295,7 +295,7 @@ void CharacteristicWindows::_on_write_requested(const std::shared_ptr<NativeStat
     GattWriteRequest request{nullptr};
     bool should_respond = false;
     try {
-        if (!native->active()) {
+        if (!native->is_active()) {
             deferral.Complete();
             return;
         }
@@ -310,7 +310,7 @@ void CharacteristicWindows::_on_write_requested(const std::shared_ptr<NativeStat
         }
 
         should_respond = request.Option() == GattWriteOption::WriteWithResponse;
-        if (!native->active()) {
+        if (!native->is_active()) {
             if (should_respond) {
                 request.RespondWithProtocolError(ATT_ERROR_UNLIKELY);
             }
@@ -341,7 +341,7 @@ void CharacteristicWindows::_on_write_requested(const std::shared_ptr<NativeStat
             _value = updated;
         }
 
-        if (native->active()) {
+        if (native->is_active()) {
             SAFE_CALLBACK_CALL(_callback_on_write, updated);
         }
         if (should_respond) {
@@ -370,7 +370,7 @@ void CharacteristicWindows::_on_write_requested(const std::shared_ptr<NativeStat
 
 void CharacteristicWindows::_on_subscribed_clients_changed(const std::shared_ptr<NativeState>& native) {
     try {
-        if (!native->active()) {
+        if (!native->is_active()) {
             return;
         }
 
@@ -380,13 +380,13 @@ void CharacteristicWindows::_on_subscribed_clients_changed(const std::shared_ptr
                 native->session_observer(client.Session());
             }
         }
-        if (!native->active()) {
+        if (!native->is_active()) {
             return;
         }
 
         const bool subscribed = clients.Size() > 0;
         const bool changed = native->subscribed.exchange(subscribed) != subscribed;
-        if (changed && native->active()) {
+        if (changed && native->is_active()) {
             if (subscribed) {
                 SAFE_CALLBACK_CALL(_callback_on_subscribed);
             } else {

--- a/simpleble/src/backends/windows/LocalCharacteristicWindows.cpp
+++ b/simpleble/src/backends/windows/LocalCharacteristicWindows.cpp
@@ -1,0 +1,461 @@
+#include "LocalCharacteristicWindows.h"
+
+#include <algorithm>
+#include <utility>
+
+#include <simpleble/Exceptions.h>
+
+#include "CommonUtils.h"
+#include "LoggingInternal.h"
+#include "MtaManager.h"
+#include "Utils.h"
+
+namespace SimpleBLE::Local {
+
+using namespace winrt::Windows::Devices::Bluetooth;
+using namespace winrt::Windows::Devices::Bluetooth::GenericAttributeProfile;
+
+namespace {
+
+constexpr uint8_t ATT_ERROR_INVALID_OFFSET = 0x07;
+constexpr uint8_t ATT_ERROR_UNLIKELY = 0x0e;
+
+GattCharacteristicProperties properties_from_capabilities(const std::set<CharacteristicCapability>& capabilities) {
+    GattCharacteristicProperties properties = GattCharacteristicProperties::None;
+    for (const auto capability : capabilities) {
+        switch (capability) {
+            case CharacteristicCapability::READ:
+                properties = properties | GattCharacteristicProperties::Read;
+                break;
+            case CharacteristicCapability::WRITE_REQUEST:
+                properties = properties | GattCharacteristicProperties::Write;
+                break;
+            case CharacteristicCapability::WRITE_COMMAND:
+                properties = properties | GattCharacteristicProperties::WriteWithoutResponse;
+                break;
+            case CharacteristicCapability::NOTIFY:
+                properties = properties | GattCharacteristicProperties::Notify;
+                break;
+            case CharacteristicCapability::INDICATE:
+                properties = properties | GattCharacteristicProperties::Indicate;
+                break;
+        }
+    }
+    return properties;
+}
+
+}  // namespace
+
+CharacteristicWindows::CharacteristicWindows(const GattLocalService& service, BluetoothUUID uuid,
+                                             std::set<CharacteristicCapability> capabilities,
+                                             SessionObserver session_observer, ActivityObserver activity_observer,
+                                             CallbackObserver callback_observer)
+    : _uuid(std::move(uuid)),
+      _capabilities(std::move(capabilities)),
+      _session_observer(std::move(session_observer)),
+      _activity_observer(std::move(activity_observer)),
+      _callback_observer(std::move(callback_observer)) {
+    if (_capabilities.empty()) {
+        throw Exception::OperationFailed("A local characteristic requires at least one capability.");
+    }
+
+    auto parameters = GattLocalCharacteristicParameters();
+    parameters.CharacteristicProperties(properties_from_capabilities(_capabilities));
+    if (_capabilities.count(CharacteristicCapability::READ) != 0) {
+        parameters.ReadProtectionLevel(GattProtectionLevel::Plain);
+    }
+    if (_capabilities.count(CharacteristicCapability::WRITE_REQUEST) != 0 ||
+        _capabilities.count(CharacteristicCapability::WRITE_COMMAND) != 0) {
+        parameters.WriteProtectionLevel(GattProtectionLevel::Plain);
+    }
+
+    auto result = WinRT::MtaManager::get().execute_sync<GattLocalCharacteristicResult>(
+        [&]() { return async_get(service.CreateCharacteristicAsync(uuid_to_guid(_uuid), parameters)); });
+    if (result.Error() != BluetoothError::Success || !result.Characteristic()) {
+        throw Exception::OperationFailed(fmt::format("Failed to create local characteristic {} (WinRT error {}).",
+                                                     _uuid, static_cast<int32_t>(result.Error())));
+    }
+
+    _characteristic = result.Characteristic();
+}
+
+void CharacteristicWindows::initialize_handlers() {
+    auto weak_self = weak_from_this();
+    _read_requested_token_ = _characteristic.ReadRequested(
+        [weak_self](const GattLocalCharacteristic& sender, const GattReadRequestedEventArgs& args) {
+            if (auto self = weak_self.lock()) {
+                self->_on_read_requested(sender, args);
+            }
+        });
+    _write_requested_token_ = _characteristic.WriteRequested(
+        [weak_self](const GattLocalCharacteristic& sender, const GattWriteRequestedEventArgs& args) {
+            if (auto self = weak_self.lock()) {
+                self->_on_write_requested(sender, args);
+            }
+        });
+    _subscribed_clients_changed_token_ = _characteristic.SubscribedClientsChanged(
+        [weak_self](const GattLocalCharacteristic& sender, const winrt::Windows::Foundation::IInspectable& args) {
+            if (auto self = weak_self.lock()) {
+                self->_on_subscribed_clients_changed(sender, args);
+            }
+        });
+}
+
+CharacteristicWindows::~CharacteristicWindows() {
+    _callback_on_read.unload();
+    _callback_on_write.unload();
+    _callback_on_subscribed.unload();
+    _callback_on_unsubscribed.unload();
+
+    if (_characteristic) {
+        if (_read_requested_token_) {
+            try {
+                _characteristic.ReadRequested(_read_requested_token_);
+            } catch (...) {
+            }
+        }
+        if (_write_requested_token_) {
+            try {
+                _characteristic.WriteRequested(_write_requested_token_);
+            } catch (...) {
+            }
+        }
+        if (_subscribed_clients_changed_token_) {
+            try {
+                _characteristic.SubscribedClientsChanged(_subscribed_clients_changed_token_);
+            } catch (...) {
+            }
+        }
+    }
+}
+
+BluetoothUUID CharacteristicWindows::uuid() { return _uuid; }
+
+std::set<CharacteristicCapability> CharacteristicWindows::capabilities() { return _capabilities; }
+
+ByteArray CharacteristicWindows::value() {
+    std::scoped_lock lock(_value_mutex);
+    return _value;
+}
+
+void CharacteristicWindows::set_value(ByteArray value) {
+    ByteArray value_snapshot;
+    {
+        std::scoped_lock lock(_value_mutex);
+        _value = std::move(value);
+        value_snapshot = _value;
+    }
+
+    const bool can_publish = _capabilities.count(CharacteristicCapability::NOTIFY) != 0 ||
+                             _capabilities.count(CharacteristicCapability::INDICATE) != 0;
+    if (!can_publish) {
+        return;
+    }
+
+    uint64_t subscription_generation;
+    {
+        std::scoped_lock lock(_subscription_mutex);
+        if (_subscribed_clients == 0) {
+            return;
+        }
+        subscription_generation = _subscription_generation;
+    }
+    if (!_activity_observer || _activity_observer() != subscription_generation) {
+        return;
+    }
+
+    try {
+        WinRT::MtaManager::get().execute_sync([this, value_snapshot]() {
+            async_get(_characteristic.NotifyValueAsync(bytearray_to_ibuffer(value_snapshot)));
+        });
+    } catch (const std::exception& ex) {
+        SIMPLEBLE_LOG_WARN(fmt::format("Failed to publish local characteristic {}: {}", _uuid, ex.what()));
+    }
+}
+
+void CharacteristicWindows::set_callback_on_read(std::function<ByteArray()> on_read) {
+    if (on_read) {
+        _callback_on_read.load(std::move(on_read));
+    } else {
+        _callback_on_read.unload();
+    }
+}
+
+void CharacteristicWindows::set_callback_on_write(std::function<void(ByteArray)> on_write) {
+    if (on_write) {
+        _callback_on_write.load(std::move(on_write));
+    } else {
+        _callback_on_write.unload();
+    }
+}
+
+void CharacteristicWindows::set_callback_on_subscribed(std::function<void()> on_subscribed) {
+    if (on_subscribed) {
+        _callback_on_subscribed.load(std::move(on_subscribed));
+    } else {
+        _callback_on_subscribed.unload();
+    }
+}
+
+void CharacteristicWindows::set_callback_on_unsubscribed(std::function<void()> on_unsubscribed) {
+    if (on_unsubscribed) {
+        _callback_on_unsubscribed.load(std::move(on_unsubscribed));
+    } else {
+        _callback_on_unsubscribed.unload();
+    }
+}
+
+void CharacteristicWindows::reset_subscriptions() {
+    std::scoped_lock lock(_subscription_mutex);
+    _subscribed_clients = 0;
+    _subscription_generation = 0;
+    _subscription_callback_delivered = false;
+    _subscription_callback_in_progress = false;
+    ++_subscription_transition_sequence;
+    _subscription_delivery_generation = 0;
+    _subscription_delivery_sequence = 0;
+}
+
+void CharacteristicWindows::reconcile_subscriptions(uint64_t generation) noexcept {
+    // Re-read the native CCCD state after every start. WinRT may retain subscribed clients across
+    // StopAdvertising/StartAdvertising without emitting another change event.
+    _on_subscribed_clients_changed(_characteristic, nullptr, generation);
+}
+
+void CharacteristicWindows::enable_subscription_callbacks(uint64_t generation) {
+    uint64_t sequence = 0;
+    {
+        std::scoped_lock lock(_subscription_mutex);
+        if (_subscription_generation == generation && _subscribed_clients > 0 &&
+            !_subscription_callback_delivered && _callback_observer && _callback_observer(generation)) {
+            ++_subscription_transition_sequence;
+            if (!_subscription_callback_in_progress) {
+                _subscription_callback_in_progress = true;
+                _subscription_delivery_generation = generation;
+                _subscription_delivery_sequence = _subscription_transition_sequence;
+                sequence = _subscription_delivery_sequence;
+            }
+        }
+    }
+    if (sequence != 0) {
+        _deliver_subscription_callback(generation, sequence, true);
+    }
+}
+
+void CharacteristicWindows::_on_read_requested(const GattLocalCharacteristic&, const GattReadRequestedEventArgs& args) {
+    auto deferral = args.GetDeferral();
+    GattReadRequest request{nullptr};
+    try {
+        if (_session_observer) {
+            _session_observer(args.Session(), 0);
+        }
+
+        request = async_get(args.GetRequestAsync());
+        if (!request) {
+            deferral.Complete();
+            return;
+        }
+
+        ByteArray response;
+        if (_activity_observer && _activity_observer() != 0 && _callback_on_read) {
+            response = _callback_on_read();
+            std::scoped_lock lock(_value_mutex);
+            _value = response;
+        } else {
+            std::scoped_lock lock(_value_mutex);
+            response = _value;
+        }
+
+        const size_t offset = request.Offset();
+        if (offset > response.size()) {
+            request.RespondWithProtocolError(ATT_ERROR_INVALID_OFFSET);
+        } else {
+            const size_t response_size = std::min(response.size() - offset, static_cast<size_t>(request.Length()));
+            request.RespondWithValue(bytearray_to_ibuffer(response.slice(offset, offset + response_size)));
+        }
+    } catch (const std::exception& ex) {
+        SIMPLEBLE_LOG_ERROR(fmt::format("Exception while handling local characteristic {} read: {}", _uuid, ex.what()));
+        try {
+            if (request) {
+                request.RespondWithProtocolError(ATT_ERROR_UNLIKELY);
+            }
+        } catch (...) {
+        }
+    } catch (...) {
+        SIMPLEBLE_LOG_ERROR(fmt::format("Unknown exception while handling local characteristic {} read", _uuid));
+        try {
+            if (request) {
+                request.RespondWithProtocolError(ATT_ERROR_UNLIKELY);
+            }
+        } catch (...) {
+        }
+    }
+    deferral.Complete();
+}
+
+void CharacteristicWindows::_on_write_requested(const GattLocalCharacteristic&,
+                                                const GattWriteRequestedEventArgs& args) {
+    auto deferral = args.GetDeferral();
+    GattWriteRequest request{nullptr};
+    bool should_respond = false;
+    try {
+        if (_session_observer) {
+            _session_observer(args.Session(), 0);
+        }
+
+        request = async_get(args.GetRequestAsync());
+        if (!request) {
+            deferral.Complete();
+            return;
+        }
+
+        should_respond = request.Option() == GattWriteOption::WriteWithResponse;
+        const ByteArray incoming = ibuffer_to_bytearray(request.Value());
+        const size_t offset = request.Offset();
+        ByteArray updated;
+        {
+            std::scoped_lock lock(_value_mutex);
+            if (offset > _value.size()) {
+                if (should_respond) {
+                    request.RespondWithProtocolError(ATT_ERROR_INVALID_OFFSET);
+                }
+                deferral.Complete();
+                return;
+            }
+
+            if (offset == 0) {
+                updated = incoming;
+            } else {
+                updated = _value;
+                updated.resize(std::max(updated.size(), offset + incoming.size()));
+                std::copy(incoming.begin(), incoming.end(), updated.begin() + offset);
+            }
+            _value = updated;
+        }
+
+        if (_activity_observer && _activity_observer() != 0) {
+            SAFE_CALLBACK_CALL(_callback_on_write, updated);
+        }
+        if (should_respond) {
+            request.Respond();
+        }
+    } catch (const std::exception& ex) {
+        SIMPLEBLE_LOG_ERROR(
+            fmt::format("Exception while handling local characteristic {} write: {}", _uuid, ex.what()));
+        try {
+            if (request && should_respond) {
+                request.RespondWithProtocolError(ATT_ERROR_UNLIKELY);
+            }
+        } catch (...) {
+        }
+    } catch (...) {
+        SIMPLEBLE_LOG_ERROR(fmt::format("Unknown exception while handling local characteristic {} write", _uuid));
+        try {
+            if (request && should_respond) {
+                request.RespondWithProtocolError(ATT_ERROR_UNLIKELY);
+            }
+        } catch (...) {
+        }
+    }
+    deferral.Complete();
+}
+
+void CharacteristicWindows::_on_subscribed_clients_changed(const GattLocalCharacteristic& sender,
+                                                           const winrt::Windows::Foundation::IInspectable&,
+                                                           uint64_t expected_generation) {
+    try {
+        const uint64_t generation = _activity_observer ? _activity_observer() : 0;
+        if (generation == 0 || (expected_generation != 0 && generation != expected_generation)) {
+            return;
+        }
+
+        const auto clients = sender.SubscribedClients();
+        for (const auto& client : clients) {
+            if (_session_observer) {
+                _session_observer(client.Session(), generation);
+            }
+        }
+
+        uint64_t delivery_sequence = 0;
+        bool delivery_state = false;
+        {
+            std::scoped_lock lock(_subscription_mutex);
+            if (!_activity_observer || _activity_observer() != generation ||
+                (expected_generation != 0 && generation != expected_generation)) {
+                return;
+            }
+
+            const bool previous_state =
+                _subscription_generation == generation ? _subscribed_clients > 0 : false;
+            _subscribed_clients = clients.Size();
+            _subscription_generation = generation;
+            const bool current_state = _subscribed_clients > 0;
+            const bool callbacks_enabled = _callback_observer && _callback_observer(generation);
+            if (previous_state != current_state) {
+                ++_subscription_transition_sequence;
+            }
+            if (callbacks_enabled && current_state != _subscription_callback_delivered &&
+                !_subscription_callback_in_progress) {
+                _subscription_callback_in_progress = true;
+                _subscription_delivery_generation = generation;
+                _subscription_delivery_sequence = _subscription_transition_sequence;
+                delivery_sequence = _subscription_delivery_sequence;
+                delivery_state = current_state;
+            }
+        }
+
+        if (delivery_sequence != 0) {
+            _deliver_subscription_callback(generation, delivery_sequence, delivery_state);
+        }
+    } catch (const std::exception& ex) {
+        SIMPLEBLE_LOG_ERROR(
+            fmt::format("Exception while handling local characteristic {} subscriptions: {}", _uuid, ex.what()));
+    } catch (...) {
+        SIMPLEBLE_LOG_ERROR(
+            fmt::format("Unknown exception while handling local characteristic {} subscriptions", _uuid));
+    }
+}
+
+void CharacteristicWindows::_deliver_subscription_callback(uint64_t generation, uint64_t sequence, bool subscribed) {
+    while (true) {
+        if (!_callback_observer || !_callback_observer(generation)) {
+            std::scoped_lock lock(_subscription_mutex);
+            if (_subscription_delivery_generation == generation && _subscription_delivery_sequence == sequence) {
+                _subscription_callback_in_progress = false;
+                _subscription_delivery_generation = 0;
+                _subscription_delivery_sequence = 0;
+            }
+            return;
+        }
+
+        if (subscribed) {
+            SAFE_CALLBACK_CALL(_callback_on_subscribed);
+        } else {
+            SAFE_CALLBACK_CALL(_callback_on_unsubscribed);
+        }
+
+        {
+            std::scoped_lock lock(_subscription_mutex);
+            if (_subscription_delivery_generation != generation || _subscription_delivery_sequence != sequence ||
+                _subscription_generation != generation) {
+                return;
+            }
+
+            _subscription_callback_delivered = subscribed;
+            const bool current_state = _subscribed_clients > 0;
+            if (current_state == _subscription_callback_delivered || !_callback_observer ||
+                !_callback_observer(generation)) {
+                _subscription_callback_in_progress = false;
+                _subscription_delivery_generation = 0;
+                _subscription_delivery_sequence = 0;
+                return;
+            }
+
+            sequence = _subscription_transition_sequence;
+            subscribed = current_state;
+            _subscription_delivery_sequence = sequence;
+        }
+    }
+}
+
+}  // namespace SimpleBLE::Local

--- a/simpleble/src/backends/windows/LocalCharacteristicWindows.cpp
+++ b/simpleble/src/backends/windows/LocalCharacteristicWindows.cpp
@@ -46,16 +46,24 @@ GattCharacteristicProperties properties_from_capabilities(const std::set<Charact
 
 }  // namespace
 
-CharacteristicWindows::CharacteristicWindows(const GattLocalService& service, BluetoothUUID uuid,
-                                             std::set<CharacteristicCapability> capabilities,
-                                             SessionObserver session_observer, ActivityObserver activity_observer)
-    : _uuid(std::move(uuid)),
-      _capabilities(std::move(capabilities)),
-      _session_observer(std::move(session_observer)),
-      _activity_observer(std::move(activity_observer)) {
+CharacteristicWindows::CharacteristicWindows(BluetoothUUID uuid, std::set<CharacteristicCapability> capabilities)
+    : _uuid(std::move(uuid)), _capabilities(std::move(capabilities)) {
     if (_capabilities.empty()) {
         throw Exception::OperationFailed("A local characteristic requires at least one capability.");
     }
+}
+
+CharacteristicWindows::~CharacteristicWindows() {
+    _callback_on_read.unload();
+    _callback_on_write.unload();
+    _callback_on_subscribed.unload();
+    _callback_on_unsubscribed.unload();
+    stop_native();
+}
+
+void CharacteristicWindows::start_native(const GattLocalService& service, SessionObserver session_observer,
+                                         ActivityObserver activity_observer) {
+    stop_native();
 
     auto parameters = GattLocalCharacteristicParameters();
     parameters.CharacteristicProperties(properties_from_capabilities(_capabilities));
@@ -74,57 +82,54 @@ CharacteristicWindows::CharacteristicWindows(const GattLocalService& service, Bl
                                                      _uuid, static_cast<int32_t>(result.Error())));
     }
 
-    _characteristic = result.Characteristic();
-}
+    auto native = std::make_shared<NativeState>();
+    native->characteristic = result.Characteristic();
+    native->session_observer = std::move(session_observer);
+    native->activity_observer = std::move(activity_observer);
 
-void CharacteristicWindows::initialize_handlers() {
     auto weak_self = weak_from_this();
-    _read_requested_token_ = _characteristic.ReadRequested(
-        [weak_self](const GattLocalCharacteristic& sender, const GattReadRequestedEventArgs& args) {
-            if (auto self = weak_self.lock()) {
-                self->_on_read_requested(sender, args);
-            }
-        });
-    _write_requested_token_ = _characteristic.WriteRequested(
-        [weak_self](const GattLocalCharacteristic& sender, const GattWriteRequestedEventArgs& args) {
-            if (auto self = weak_self.lock()) {
-                self->_on_write_requested(sender, args);
-            }
-        });
-    _subscribed_clients_changed_token_ = _characteristic.SubscribedClientsChanged(
-        [weak_self](const GattLocalCharacteristic& sender, const winrt::Windows::Foundation::IInspectable& args) {
-            if (auto self = weak_self.lock()) {
-                self->_on_subscribed_clients_changed(sender, args);
-            }
-        });
+    std::weak_ptr<NativeState> weak_native = native;
+    try {
+        native->read_requested_token = native->characteristic.ReadRequested(
+            [weak_self, weak_native](const GattLocalCharacteristic&, const GattReadRequestedEventArgs& args) {
+                if (auto self = weak_self.lock()) {
+                    if (auto state = weak_native.lock()) {
+                        self->_on_read_requested(state, args);
+                    }
+                }
+            });
+        native->write_requested_token = native->characteristic.WriteRequested(
+            [weak_self, weak_native](const GattLocalCharacteristic&, const GattWriteRequestedEventArgs& args) {
+                if (auto self = weak_self.lock()) {
+                    if (auto state = weak_native.lock()) {
+                        self->_on_write_requested(state, args);
+                    }
+                }
+            });
+        native->subscribed_clients_changed_token = native->characteristic.SubscribedClientsChanged(
+            [weak_self, weak_native](const GattLocalCharacteristic&, const winrt::Windows::Foundation::IInspectable&) {
+                if (auto self = weak_self.lock()) {
+                    if (auto state = weak_native.lock()) {
+                        self->_on_subscribed_clients_changed(state);
+                    }
+                }
+            });
+    } catch (...) {
+        _revoke_handlers(native);
+        throw;
+    }
+
+    std::scoped_lock lock(_native_mutex);
+    _native = std::move(native);
 }
 
-CharacteristicWindows::~CharacteristicWindows() {
-    _callback_on_read.unload();
-    _callback_on_write.unload();
-    _callback_on_subscribed.unload();
-    _callback_on_unsubscribed.unload();
-
-    if (_characteristic) {
-        if (_read_requested_token_) {
-            try {
-                _characteristic.ReadRequested(_read_requested_token_);
-            } catch (...) {
-            }
-        }
-        if (_write_requested_token_) {
-            try {
-                _characteristic.WriteRequested(_write_requested_token_);
-            } catch (...) {
-            }
-        }
-        if (_subscribed_clients_changed_token_) {
-            try {
-                _characteristic.SubscribedClientsChanged(_subscribed_clients_changed_token_);
-            } catch (...) {
-            }
-        }
+void CharacteristicWindows::stop_native() noexcept {
+    std::shared_ptr<NativeState> native;
+    {
+        std::scoped_lock lock(_native_mutex);
+        native.swap(_native);
     }
+    _revoke_handlers(native);
 }
 
 BluetoothUUID CharacteristicWindows::uuid() { return _uuid; }
@@ -146,17 +151,16 @@ void CharacteristicWindows::set_value(ByteArray value) {
 
     const bool can_publish = _capabilities.count(CharacteristicCapability::NOTIFY) != 0 ||
                              _capabilities.count(CharacteristicCapability::INDICATE) != 0;
-    if (!can_publish) {
-        return;
-    }
-
-    if (!_subscribed.load() || !_activity_observer || _activity_observer() == 0) {
+    const auto native = _native_snapshot();
+    if (!can_publish || !native || !native->subscribed.load() || !native->active()) {
         return;
     }
 
     try {
-        WinRT::MtaManager::get().execute_sync([this, value_snapshot]() {
-            async_get(_characteristic.NotifyValueAsync(bytearray_to_ibuffer(value_snapshot)));
+        WinRT::MtaManager::get().execute_sync([native, value_snapshot]() {
+            if (native->active()) {
+                async_get(native->characteristic.NotifyValueAsync(bytearray_to_ibuffer(value_snapshot)));
+            }
         });
     } catch (const std::exception& ex) {
         SIMPLEBLE_LOG_WARN(fmt::format("Failed to publish local characteristic {}: {}", _uuid, ex.what()));
@@ -195,14 +199,46 @@ void CharacteristicWindows::set_callback_on_unsubscribed(std::function<void()> o
     }
 }
 
-void CharacteristicWindows::reset_subscriptions() { _subscribed.store(false); }
+std::shared_ptr<CharacteristicWindows::NativeState> CharacteristicWindows::_native_snapshot() {
+    std::scoped_lock lock(_native_mutex);
+    return _native;
+}
 
-void CharacteristicWindows::_on_read_requested(const GattLocalCharacteristic&, const GattReadRequestedEventArgs& args) {
+void CharacteristicWindows::_revoke_handlers(const std::shared_ptr<NativeState>& native) noexcept {
+    if (!native || !native->characteristic) {
+        return;
+    }
+    try {
+        if (native->read_requested_token) {
+            native->characteristic.ReadRequested(native->read_requested_token);
+        }
+    } catch (...) {
+    }
+    try {
+        if (native->write_requested_token) {
+            native->characteristic.WriteRequested(native->write_requested_token);
+        }
+    } catch (...) {
+    }
+    try {
+        if (native->subscribed_clients_changed_token) {
+            native->characteristic.SubscribedClientsChanged(native->subscribed_clients_changed_token);
+        }
+    } catch (...) {
+    }
+}
+
+void CharacteristicWindows::_on_read_requested(const std::shared_ptr<NativeState>& native,
+                                               const GattReadRequestedEventArgs& args) {
     auto deferral = args.GetDeferral();
     GattReadRequest request{nullptr};
     try {
-        if (_session_observer) {
-            _session_observer(args.Session(), 0);
+        if (!native->active()) {
+            deferral.Complete();
+            return;
+        }
+        if (native->session_observer) {
+            native->session_observer(args.Session());
         }
 
         request = async_get(args.GetRequestAsync());
@@ -210,16 +246,14 @@ void CharacteristicWindows::_on_read_requested(const GattLocalCharacteristic&, c
             deferral.Complete();
             return;
         }
-
-        const uint64_t generation = _activity_observer ? _activity_observer() : 0;
-        if (generation == 0) {
+        if (!native->active()) {
             request.RespondWithProtocolError(ATT_ERROR_UNLIKELY);
             deferral.Complete();
             return;
         }
 
         ByteArray response;
-        if (_activity_observer && _activity_observer() == generation && _callback_on_read) {
+        if (_callback_on_read && native->active()) {
             response = _callback_on_read();
             std::scoped_lock lock(_value_mutex);
             _value = response;
@@ -255,14 +289,18 @@ void CharacteristicWindows::_on_read_requested(const GattLocalCharacteristic&, c
     deferral.Complete();
 }
 
-void CharacteristicWindows::_on_write_requested(const GattLocalCharacteristic&,
+void CharacteristicWindows::_on_write_requested(const std::shared_ptr<NativeState>& native,
                                                 const GattWriteRequestedEventArgs& args) {
     auto deferral = args.GetDeferral();
     GattWriteRequest request{nullptr};
     bool should_respond = false;
     try {
-        if (_session_observer) {
-            _session_observer(args.Session(), 0);
+        if (!native->active()) {
+            deferral.Complete();
+            return;
+        }
+        if (native->session_observer) {
+            native->session_observer(args.Session());
         }
 
         request = async_get(args.GetRequestAsync());
@@ -272,14 +310,14 @@ void CharacteristicWindows::_on_write_requested(const GattLocalCharacteristic&,
         }
 
         should_respond = request.Option() == GattWriteOption::WriteWithResponse;
-        const uint64_t generation = _activity_observer ? _activity_observer() : 0;
-        if (generation == 0) {
+        if (!native->active()) {
             if (should_respond) {
                 request.RespondWithProtocolError(ATT_ERROR_UNLIKELY);
             }
             deferral.Complete();
             return;
         }
+
         const ByteArray incoming = ibuffer_to_bytearray(request.Value());
         const size_t offset = request.Offset();
         ByteArray updated;
@@ -303,7 +341,7 @@ void CharacteristicWindows::_on_write_requested(const GattLocalCharacteristic&,
             _value = updated;
         }
 
-        if (_activity_observer && _activity_observer() == generation) {
+        if (native->active()) {
             SAFE_CALLBACK_CALL(_callback_on_write, updated);
         }
         if (should_respond) {
@@ -330,25 +368,25 @@ void CharacteristicWindows::_on_write_requested(const GattLocalCharacteristic&,
     deferral.Complete();
 }
 
-void CharacteristicWindows::_on_subscribed_clients_changed(const GattLocalCharacteristic& sender,
-                                                           const winrt::Windows::Foundation::IInspectable&) {
+void CharacteristicWindows::_on_subscribed_clients_changed(const std::shared_ptr<NativeState>& native) {
     try {
-        const uint64_t generation = _activity_observer ? _activity_observer() : 0;
-        if (generation == 0) {
+        if (!native->active()) {
             return;
         }
 
-        const auto clients = sender.SubscribedClients();
+        const auto clients = native->characteristic.SubscribedClients();
         for (const auto& client : clients) {
-            if (_session_observer) {
-                _session_observer(client.Session(), generation);
+            if (native->session_observer) {
+                native->session_observer(client.Session());
             }
+        }
+        if (!native->active()) {
+            return;
         }
 
         const bool subscribed = clients.Size() > 0;
-        const bool changed = _subscribed.exchange(subscribed) != subscribed;
-
-        if (changed && _activity_observer && _activity_observer() == generation) {
+        const bool changed = native->subscribed.exchange(subscribed) != subscribed;
+        if (changed && native->active()) {
             if (subscribed) {
                 SAFE_CALLBACK_CALL(_callback_on_subscribed);
             } else {

--- a/simpleble/src/backends/windows/LocalCharacteristicWindows.cpp
+++ b/simpleble/src/backends/windows/LocalCharacteristicWindows.cpp
@@ -48,13 +48,11 @@ GattCharacteristicProperties properties_from_capabilities(const std::set<Charact
 
 CharacteristicWindows::CharacteristicWindows(const GattLocalService& service, BluetoothUUID uuid,
                                              std::set<CharacteristicCapability> capabilities,
-                                             SessionObserver session_observer, ActivityObserver activity_observer,
-                                             CallbackObserver callback_observer)
+                                             SessionObserver session_observer, ActivityObserver activity_observer)
     : _uuid(std::move(uuid)),
       _capabilities(std::move(capabilities)),
       _session_observer(std::move(session_observer)),
-      _activity_observer(std::move(activity_observer)),
-      _callback_observer(std::move(callback_observer)) {
+      _activity_observer(std::move(activity_observer)) {
     if (_capabilities.empty()) {
         throw Exception::OperationFailed("A local characteristic requires at least one capability.");
     }
@@ -152,15 +150,7 @@ void CharacteristicWindows::set_value(ByteArray value) {
         return;
     }
 
-    uint64_t subscription_generation;
-    {
-        std::scoped_lock lock(_subscription_mutex);
-        if (_subscribed_clients == 0) {
-            return;
-        }
-        subscription_generation = _subscription_generation;
-    }
-    if (!_activity_observer || _activity_observer() != subscription_generation) {
+    if (!_subscribed.load() || !_activity_observer || _activity_observer() == 0) {
         return;
     }
 
@@ -205,33 +195,7 @@ void CharacteristicWindows::set_callback_on_unsubscribed(std::function<void()> o
     }
 }
 
-void CharacteristicWindows::reset_subscriptions() {
-    std::scoped_lock lock(_subscription_mutex);
-    _subscribed_clients = 0;
-    _subscription_generation = 0;
-    _subscription_callbacks_enabled = false;
-}
-
-void CharacteristicWindows::reconcile_subscriptions(uint64_t generation) noexcept {
-    // Re-read the native CCCD state after every start. WinRT may retain subscribed clients across
-    // StopAdvertising/StartAdvertising without emitting another change event.
-    _on_subscribed_clients_changed(_characteristic, nullptr, generation);
-}
-
-void CharacteristicWindows::enable_subscription_callbacks(uint64_t generation) {
-    bool notify_subscribed = false;
-    {
-        std::scoped_lock lock(_subscription_mutex);
-        if (_subscription_generation == generation && !_subscription_callbacks_enabled && _callback_observer &&
-            _callback_observer(generation)) {
-            _subscription_callbacks_enabled = true;
-            notify_subscribed = _subscribed_clients > 0;
-        }
-    }
-    if (notify_subscribed && _callback_observer && _callback_observer(generation)) {
-        SAFE_CALLBACK_CALL(_callback_on_subscribed);
-    }
-}
+void CharacteristicWindows::reset_subscriptions() { _subscribed.store(false); }
 
 void CharacteristicWindows::_on_read_requested(const GattLocalCharacteristic&, const GattReadRequestedEventArgs& args) {
     auto deferral = args.GetDeferral();
@@ -367,11 +331,10 @@ void CharacteristicWindows::_on_write_requested(const GattLocalCharacteristic&,
 }
 
 void CharacteristicWindows::_on_subscribed_clients_changed(const GattLocalCharacteristic& sender,
-                                                           const winrt::Windows::Foundation::IInspectable&,
-                                                           uint64_t expected_generation) {
+                                                           const winrt::Windows::Foundation::IInspectable&) {
     try {
         const uint64_t generation = _activity_observer ? _activity_observer() : 0;
-        if (generation == 0 || (expected_generation != 0 && generation != expected_generation)) {
+        if (generation == 0) {
             return;
         }
 
@@ -382,24 +345,10 @@ void CharacteristicWindows::_on_subscribed_clients_changed(const GattLocalCharac
             }
         }
 
-        bool notify = false;
-        bool subscribed = false;
-        {
-            std::scoped_lock lock(_subscription_mutex);
-            if (!_activity_observer || _activity_observer() != generation ||
-                (expected_generation != 0 && generation != expected_generation)) {
-                return;
-            }
+        const bool subscribed = clients.Size() > 0;
+        const bool changed = _subscribed.exchange(subscribed) != subscribed;
 
-            const bool was_subscribed = _subscription_generation == generation && _subscribed_clients > 0;
-            _subscribed_clients = clients.Size();
-            _subscription_generation = generation;
-            subscribed = _subscribed_clients > 0;
-            notify = _subscription_callbacks_enabled && _callback_observer && _callback_observer(generation) &&
-                     was_subscribed != subscribed;
-        }
-
-        if (notify && _callback_observer && _callback_observer(generation)) {
+        if (changed && _activity_observer && _activity_observer() == generation) {
             if (subscribed) {
                 SAFE_CALLBACK_CALL(_callback_on_subscribed);
             } else {

--- a/simpleble/src/backends/windows/LocalCharacteristicWindows.h
+++ b/simpleble/src/backends/windows/LocalCharacteristicWindows.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <atomic>
-#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -19,15 +18,15 @@ namespace SimpleBLE::Local {
 class CharacteristicWindows : public CharacteristicBase, public std::enable_shared_from_this<CharacteristicWindows> {
   public:
     using GattSession = winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattSession;
-    using SessionObserver = std::function<void(const GattSession&, uint64_t expected_generation)>;
-    using ActivityObserver = std::function<uint64_t()>;
+    using SessionObserver = std::function<void(const GattSession&)>;
+    using ActivityObserver = std::function<bool()>;
 
-    CharacteristicWindows(const winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattLocalService& service,
-                          BluetoothUUID uuid, std::set<CharacteristicCapability> capabilities,
-                          SessionObserver session_observer, ActivityObserver activity_observer);
+    CharacteristicWindows(BluetoothUUID uuid, std::set<CharacteristicCapability> capabilities);
     ~CharacteristicWindows() override;
 
-    void initialize_handlers();
+    void start_native(const winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattLocalService& service,
+                      SessionObserver session_observer, ActivityObserver activity_observer);
+    void stop_native() noexcept;
 
     BluetoothUUID uuid() override;
     std::set<CharacteristicCapability> capabilities() override;
@@ -41,8 +40,6 @@ class CharacteristicWindows : public CharacteristicBase, public std::enable_shar
     void set_callback_on_subscribed(std::function<void()> on_subscribed) override;
     void set_callback_on_unsubscribed(std::function<void()> on_unsubscribed) override;
 
-    void reset_subscriptions();
-
   private:
     using GattLocalCharacteristic =
         winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattLocalCharacteristic;
@@ -51,29 +48,36 @@ class CharacteristicWindows : public CharacteristicBase, public std::enable_shar
     using GattWriteRequestedEventArgs =
         winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattWriteRequestedEventArgs;
 
-    GattLocalCharacteristic _characteristic{nullptr};
+    struct NativeState {
+        GattLocalCharacteristic characteristic{nullptr};
+        SessionObserver session_observer;
+        ActivityObserver activity_observer;
+        std::atomic_bool subscribed{false};
+        winrt::event_token read_requested_token{};
+        winrt::event_token write_requested_token{};
+        winrt::event_token subscribed_clients_changed_token{};
+
+        bool active() const { return activity_observer && activity_observer(); }
+    };
+
     BluetoothUUID _uuid;
     std::set<CharacteristicCapability> _capabilities;
-    SessionObserver _session_observer;
-    ActivityObserver _activity_observer;
 
     ByteArray _value;
     std::mutex _value_mutex;
-    std::atomic_bool _subscribed{false};
-
-    winrt::event_token _read_requested_token_{};
-    winrt::event_token _write_requested_token_{};
-    winrt::event_token _subscribed_clients_changed_token_{};
+    std::shared_ptr<NativeState> _native;
+    std::mutex _native_mutex;
 
     kvn::safe_callback<ByteArray()> _callback_on_read;
     kvn::safe_callback<void(ByteArray)> _callback_on_write;
     kvn::safe_callback<void()> _callback_on_subscribed;
     kvn::safe_callback<void()> _callback_on_unsubscribed;
 
-    void _on_read_requested(const GattLocalCharacteristic& sender, const GattReadRequestedEventArgs& args);
-    void _on_write_requested(const GattLocalCharacteristic& sender, const GattWriteRequestedEventArgs& args);
-    void _on_subscribed_clients_changed(const GattLocalCharacteristic& sender,
-                                        const winrt::Windows::Foundation::IInspectable& args);
+    std::shared_ptr<NativeState> _native_snapshot();
+    static void _revoke_handlers(const std::shared_ptr<NativeState>& native) noexcept;
+    void _on_read_requested(const std::shared_ptr<NativeState>& native, const GattReadRequestedEventArgs& args);
+    void _on_write_requested(const std::shared_ptr<NativeState>& native, const GattWriteRequestedEventArgs& args);
+    void _on_subscribed_clients_changed(const std::shared_ptr<NativeState>& native);
 };
 
 }  // namespace SimpleBLE::Local

--- a/simpleble/src/backends/windows/LocalCharacteristicWindows.h
+++ b/simpleble/src/backends/windows/LocalCharacteristicWindows.h
@@ -65,11 +65,7 @@ class CharacteristicWindows : public CharacteristicBase, public std::enable_shar
     std::mutex _value_mutex;
     size_t _subscribed_clients{0};
     uint64_t _subscription_generation{0};
-    bool _subscription_callback_delivered{false};
-    bool _subscription_callback_in_progress{false};
-    uint64_t _subscription_transition_sequence{0};
-    uint64_t _subscription_delivery_generation{0};
-    uint64_t _subscription_delivery_sequence{0};
+    bool _subscription_callbacks_enabled{false};
     std::mutex _subscription_mutex;
 
     winrt::event_token _read_requested_token_{};
@@ -86,7 +82,6 @@ class CharacteristicWindows : public CharacteristicBase, public std::enable_shar
     void _on_subscribed_clients_changed(const GattLocalCharacteristic& sender,
                                         const winrt::Windows::Foundation::IInspectable& args,
                                         uint64_t expected_generation = 0);
-    void _deliver_subscription_callback(uint64_t generation, uint64_t sequence, bool subscribed);
 };
 
 }  // namespace SimpleBLE::Local

--- a/simpleble/src/backends/windows/LocalCharacteristicWindows.h
+++ b/simpleble/src/backends/windows/LocalCharacteristicWindows.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <atomic>
-#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -19,14 +18,13 @@ class CharacteristicWindows : public CharacteristicBase, public std::enable_shar
   public:
     using GattSession = winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattSession;
     using SessionObserver = std::function<void(const GattSession&)>;
-    using ActivityObserver = std::function<bool()>;
 
     CharacteristicWindows(BluetoothUUID uuid, std::set<CharacteristicCapability> capabilities);
     ~CharacteristicWindows() override;
 
-    void start_native(const winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattLocalService& service,
-                      SessionObserver session_observer, ActivityObserver activity_observer);
-    void stop_native() noexcept;
+    void create_native(const winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattLocalService& service,
+                       SessionObserver session_observer, std::shared_ptr<std::atomic_bool> active);
+    void destroy_native() noexcept;
 
     BluetoothUUID uuid() override;
     std::set<CharacteristicCapability> capabilities() override;
@@ -51,13 +49,13 @@ class CharacteristicWindows : public CharacteristicBase, public std::enable_shar
     struct NativeState {
         GattLocalCharacteristic characteristic{nullptr};
         SessionObserver session_observer;
-        ActivityObserver activity_observer;
+        std::shared_ptr<std::atomic_bool> active;
         std::atomic_bool subscribed{false};
         winrt::event_token read_requested_token{};
         winrt::event_token write_requested_token{};
         winrt::event_token subscribed_clients_changed_token{};
 
-        bool active() const { return activity_observer && activity_observer(); }
+        bool is_active() const { return active && active->load(); }
     };
 
     BluetoothUUID _uuid;
@@ -73,7 +71,7 @@ class CharacteristicWindows : public CharacteristicBase, public std::enable_shar
     kvn::safe_callback<void()> _callback_on_subscribed;
     kvn::safe_callback<void()> _callback_on_unsubscribed;
 
-    std::shared_ptr<NativeState> _native_snapshot();
+    std::shared_ptr<NativeState> _native_state();
     static void _revoke_handlers(const std::shared_ptr<NativeState>& native) noexcept;
     void _on_read_requested(const std::shared_ptr<NativeState>& native, const GattReadRequestedEventArgs& args);
     void _on_write_requested(const std::shared_ptr<NativeState>& native, const GattWriteRequestedEventArgs& args);

--- a/simpleble/src/backends/windows/LocalCharacteristicWindows.h
+++ b/simpleble/src/backends/windows/LocalCharacteristicWindows.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <set>
+
+#include <kvn_safe_callback.hpp>
+
+#include "../common/LocalCharacteristicBase.h"
+#include "winrt/Windows.Devices.Bluetooth.GenericAttributeProfile.h"
+#include "winrt/Windows.Foundation.Collections.h"
+
+namespace SimpleBLE::Local {
+
+class CharacteristicWindows : public CharacteristicBase, public std::enable_shared_from_this<CharacteristicWindows> {
+  public:
+    using GattSession = winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattSession;
+    using SessionObserver = std::function<void(const GattSession&, uint64_t expected_generation)>;
+    using ActivityObserver = std::function<uint64_t()>;
+    using CallbackObserver = std::function<bool(uint64_t)>;
+
+    CharacteristicWindows(const winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattLocalService& service,
+                          BluetoothUUID uuid, std::set<CharacteristicCapability> capabilities,
+                          SessionObserver session_observer, ActivityObserver activity_observer,
+                          CallbackObserver callback_observer);
+    ~CharacteristicWindows() override;
+
+    void initialize_handlers();
+
+    BluetoothUUID uuid() override;
+    std::set<CharacteristicCapability> capabilities() override;
+
+    ByteArray value() override;
+    void set_value(ByteArray value) override;
+
+    void set_callback_on_read(std::function<ByteArray()> on_read) override;
+    void set_callback_on_write(std::function<void(ByteArray value)> on_write) override;
+
+    void set_callback_on_subscribed(std::function<void()> on_subscribed) override;
+    void set_callback_on_unsubscribed(std::function<void()> on_unsubscribed) override;
+
+    void reset_subscriptions();
+    void reconcile_subscriptions(uint64_t generation) noexcept;
+    void enable_subscription_callbacks(uint64_t generation);
+
+  private:
+    using GattLocalCharacteristic =
+        winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattLocalCharacteristic;
+    using GattReadRequestedEventArgs =
+        winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattReadRequestedEventArgs;
+    using GattWriteRequestedEventArgs =
+        winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattWriteRequestedEventArgs;
+
+    GattLocalCharacteristic _characteristic{nullptr};
+    BluetoothUUID _uuid;
+    std::set<CharacteristicCapability> _capabilities;
+    SessionObserver _session_observer;
+    ActivityObserver _activity_observer;
+    CallbackObserver _callback_observer;
+
+    ByteArray _value;
+    std::mutex _value_mutex;
+    size_t _subscribed_clients{0};
+    uint64_t _subscription_generation{0};
+    bool _subscription_callback_delivered{false};
+    bool _subscription_callback_in_progress{false};
+    uint64_t _subscription_transition_sequence{0};
+    uint64_t _subscription_delivery_generation{0};
+    uint64_t _subscription_delivery_sequence{0};
+    std::mutex _subscription_mutex;
+
+    winrt::event_token _read_requested_token_{};
+    winrt::event_token _write_requested_token_{};
+    winrt::event_token _subscribed_clients_changed_token_{};
+
+    kvn::safe_callback<ByteArray()> _callback_on_read;
+    kvn::safe_callback<void(ByteArray)> _callback_on_write;
+    kvn::safe_callback<void()> _callback_on_subscribed;
+    kvn::safe_callback<void()> _callback_on_unsubscribed;
+
+    void _on_read_requested(const GattLocalCharacteristic& sender, const GattReadRequestedEventArgs& args);
+    void _on_write_requested(const GattLocalCharacteristic& sender, const GattWriteRequestedEventArgs& args);
+    void _on_subscribed_clients_changed(const GattLocalCharacteristic& sender,
+                                        const winrt::Windows::Foundation::IInspectable& args,
+                                        uint64_t expected_generation = 0);
+    void _deliver_subscription_callback(uint64_t generation, uint64_t sequence, bool subscribed);
+};
+
+}  // namespace SimpleBLE::Local

--- a/simpleble/src/backends/windows/LocalCharacteristicWindows.h
+++ b/simpleble/src/backends/windows/LocalCharacteristicWindows.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -20,12 +21,10 @@ class CharacteristicWindows : public CharacteristicBase, public std::enable_shar
     using GattSession = winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattSession;
     using SessionObserver = std::function<void(const GattSession&, uint64_t expected_generation)>;
     using ActivityObserver = std::function<uint64_t()>;
-    using CallbackObserver = std::function<bool(uint64_t)>;
 
     CharacteristicWindows(const winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattLocalService& service,
                           BluetoothUUID uuid, std::set<CharacteristicCapability> capabilities,
-                          SessionObserver session_observer, ActivityObserver activity_observer,
-                          CallbackObserver callback_observer);
+                          SessionObserver session_observer, ActivityObserver activity_observer);
     ~CharacteristicWindows() override;
 
     void initialize_handlers();
@@ -43,8 +42,6 @@ class CharacteristicWindows : public CharacteristicBase, public std::enable_shar
     void set_callback_on_unsubscribed(std::function<void()> on_unsubscribed) override;
 
     void reset_subscriptions();
-    void reconcile_subscriptions(uint64_t generation) noexcept;
-    void enable_subscription_callbacks(uint64_t generation);
 
   private:
     using GattLocalCharacteristic =
@@ -59,14 +56,10 @@ class CharacteristicWindows : public CharacteristicBase, public std::enable_shar
     std::set<CharacteristicCapability> _capabilities;
     SessionObserver _session_observer;
     ActivityObserver _activity_observer;
-    CallbackObserver _callback_observer;
 
     ByteArray _value;
     std::mutex _value_mutex;
-    size_t _subscribed_clients{0};
-    uint64_t _subscription_generation{0};
-    bool _subscription_callbacks_enabled{false};
-    std::mutex _subscription_mutex;
+    std::atomic_bool _subscribed{false};
 
     winrt::event_token _read_requested_token_{};
     winrt::event_token _write_requested_token_{};
@@ -80,8 +73,7 @@ class CharacteristicWindows : public CharacteristicBase, public std::enable_shar
     void _on_read_requested(const GattLocalCharacteristic& sender, const GattReadRequestedEventArgs& args);
     void _on_write_requested(const GattLocalCharacteristic& sender, const GattWriteRequestedEventArgs& args);
     void _on_subscribed_clients_changed(const GattLocalCharacteristic& sender,
-                                        const winrt::Windows::Foundation::IInspectable& args,
-                                        uint64_t expected_generation = 0);
+                                        const winrt::Windows::Foundation::IInspectable& args);
 };
 
 }  // namespace SimpleBLE::Local

--- a/simpleble/src/backends/windows/LocalPeripheralWindows.cpp
+++ b/simpleble/src/backends/windows/LocalPeripheralWindows.cpp
@@ -33,6 +33,7 @@ PeripheralWindows::~PeripheralWindows() {
 
     std::scoped_lock lock(_lifecycle_mutex);
     _services.clear();
+    _run.reset();
 }
 
 void* PeripheralWindows::underlying() const {
@@ -53,28 +54,7 @@ void PeripheralWindows::set_advertisement(Advertisement advertisement) {
 std::shared_ptr<ServiceBase> PeripheralWindows::add_service(BluetoothUUID uuid) {
     std::scoped_lock lock(_lifecycle_mutex);
     _ensure_mutable();
-
-    auto weak_self = weak_from_this();
-    auto service = std::make_shared<ServiceWindows>(
-        std::move(uuid),
-        [weak_self](const GattSession& session, uint64_t expected_generation) {
-            if (auto self = weak_self.lock()) {
-                try {
-                    self->_observe_session(session, expected_generation);
-                } catch (const std::exception& ex) {
-                    SIMPLEBLE_LOG_WARN(
-                        fmt::format("Failed to observe a Windows local peripheral client: {}", ex.what()));
-                } catch (...) {
-                    SIMPLEBLE_LOG_WARN("Failed to observe a Windows local peripheral client");
-                }
-            }
-        },
-        [weak_self]() -> uint64_t {
-            if (auto self = weak_self.lock()) {
-                return self->_active_client_generation();
-            }
-            return 0;
-        });
+    auto service = std::make_shared<ServiceWindows>(std::move(uuid));
     _services.push_back(service);
     return service;
 }
@@ -136,45 +116,62 @@ void PeripheralWindows::start() {
     }
 
     const auto services_snapshot = _services;
+    auto run = std::make_shared<RunState>();
+    auto weak_self = weak_from_this();
+    std::weak_ptr<RunState> weak_run = run;
+    const ServiceWindows::SessionObserver session_observer = [weak_self, weak_run](const GattSession& session) {
+        const auto state = weak_run.lock();
+        if (!state || !state->active.load()) {
+            return;
+        }
+        if (auto self = weak_self.lock()) {
+            try {
+                self->_observe_session(state, session);
+            } catch (const std::exception& ex) {
+                SIMPLEBLE_LOG_WARN(fmt::format("Failed to observe a Windows local peripheral client: {}", ex.what()));
+            } catch (...) {
+                SIMPLEBLE_LOG_WARN("Failed to observe a Windows local peripheral client");
+            }
+        }
+    };
+    const ServiceWindows::ActivityObserver activity_observer = [weak_run]() {
+        const auto state = weak_run.lock();
+        return state && state->active.load();
+    };
+
     for (const auto& service : services_snapshot) {
         service->freeze();
     }
-
-    uint64_t generation;
-    {
-        std::scoped_lock clients_lock(_clients_mutex);
-        generation = ++_client_generation;
-        _accepting_clients = true;
-    }
-    for (const auto& service : services_snapshot) {
-        service->activate(generation);
-    }
+    _run = run;
 
     bool rollback_failed = false;
     try {
-        size_t started_count = 0;
+        for (const auto& service : services_snapshot) {
+            service->create_native(session_observer, activity_observer);
+        }
+
         try {
-            WinRT::MtaManager::get().execute_sync([&publication_order, &started_count, generation]() {
+            WinRT::MtaManager::get().execute_sync([&publication_order]() {
                 for (const auto& service : publication_order) {
                     // WinRT publishes each primary GATT service through its own provider. Starting every provider
                     // keeps the complete GATT table available. Windows owns the shared advertisement payload and may
                     // omit UUIDs that do not fit, reporting StartedWithoutAllAdvertisementData for those providers.
-                    service->start_advertising(generation);
-                    ++started_count;
+                    service->start_advertising();
                 }
             });
             // Wait on the calling thread so the process-wide MTA executor remains available to scanning, GATT I/O,
             // notifications, and status events while Windows finishes publishing the providers.
-            for (size_t index = 0; index < started_count; ++index) {
-                publication_order[index]->wait_until_advertising(generation);
+            for (const auto& service : publication_order) {
+                service->wait_until_advertising();
             }
         } catch (...) {
             const auto start_error = std::current_exception();
+            run->active.store(false);
             try {
-                WinRT::MtaManager::get().execute_sync([&publication_order, &rollback_failed, started_count]() {
-                    for (size_t index = 0; index < started_count; ++index) {
+                WinRT::MtaManager::get().execute_sync([&publication_order, &rollback_failed]() {
+                    for (const auto& service : publication_order) {
                         try {
-                            publication_order[index]->stop_advertising();
+                            service->stop_advertising();
                         } catch (...) {
                             rollback_failed = true;
                         }
@@ -187,13 +184,14 @@ void PeripheralWindows::start() {
         }
         _started.store(true);
     } catch (const std::exception& ex) {
-        _clear_client_sessions();
-        for (const auto& service : services_snapshot) {
-            service->deactivate();
-            service->reset_subscriptions();
-            if (!rollback_failed) {
+        run->active.store(false);
+        _clear_client_sessions(run);
+        if (!rollback_failed) {
+            for (const auto& service : services_snapshot) {
+                service->destroy_native();
                 service->unfreeze();
             }
+            _run.reset();
         }
         _cleanup_required = rollback_failed;
         if (rollback_failed) {
@@ -204,13 +202,14 @@ void PeripheralWindows::start() {
         SIMPLEBLE_LOG_ERROR(fmt::format("Failed to start Windows local peripheral: {}", ex.what()));
         throw;
     } catch (...) {
-        _clear_client_sessions();
-        for (const auto& service : services_snapshot) {
-            service->deactivate();
-            service->reset_subscriptions();
-            if (!rollback_failed) {
+        run->active.store(false);
+        _clear_client_sessions(run);
+        if (!rollback_failed) {
+            for (const auto& service : services_snapshot) {
+                service->destroy_native();
                 service->unfreeze();
             }
+            _run.reset();
         }
         _cleanup_required = rollback_failed;
         if (rollback_failed) {
@@ -229,10 +228,10 @@ void PeripheralWindows::stop() {
         return;
     }
 
-    _clear_client_sessions();
-    for (const auto& service : _services) {
-        service->deactivate();
-        service->reset_subscriptions();
+    const auto run = _run;
+    if (run) {
+        run->active.store(false);
+        _clear_client_sessions(run);
     }
 
     std::exception_ptr first_error;
@@ -262,8 +261,10 @@ void PeripheralWindows::stop() {
     }
 
     for (const auto& service : _services) {
+        service->destroy_native();
         service->unfreeze();
     }
+    _run.reset();
     _started.store(false);
     _cleanup_required = false;
 }
@@ -304,84 +305,121 @@ void PeripheralWindows::_ensure_mutable() const {
     }
 }
 
-void PeripheralWindows::_observe_session(const GattSession& session, uint64_t expected_generation) {
-    if (!session) {
+void PeripheralWindows::_observe_session(const std::shared_ptr<RunState>& run, const GattSession& session) {
+    if (!run || !run->active.load() || !session) {
         return;
     }
 
     const auto [key, address] = _session_identity(session);
-    uint64_t generation;
-    uint64_t sequence;
     GattSession previous_session{nullptr};
     winrt::event_token previous_token{};
     {
-        std::scoped_lock lock(_clients_mutex);
-        if (!_accepting_clients || (expected_generation != 0 && _client_generation != expected_generation)) {
+        std::scoped_lock lock(run->clients_mutex);
+        if (!run->active.load()) {
             return;
         }
-        generation = _client_generation;
-        const auto existing = _client_sessions.find(key);
-        if (existing != _client_sessions.end() && winrt::get_abi(existing->second.session) == winrt::get_abi(session)) {
+        const auto existing = run->client_sessions.find(key);
+        if (existing != run->client_sessions.end() &&
+            winrt::get_abi(existing->second.session) == winrt::get_abi(session)) {
             return;
         }
-        sequence = ++_next_client_sequence;
-        if (existing == _client_sessions.end()) {
-            _client_sessions.emplace(key, ClientSession{session, {}, address, false, generation, sequence});
+        if (existing == run->client_sessions.end()) {
+            run->client_sessions.emplace(key, ClientSession{session, {}, address, false});
         } else {
             previous_session = existing->second.session;
             previous_token = existing->second.status_changed_token;
-            existing->second = ClientSession{session, {}, address, existing->second.connected, generation, sequence};
+            existing->second = ClientSession{session, {}, address, existing->second.connected};
         }
     }
 
-    if (previous_session && previous_token) {
+    if (previous_session) {
         try {
-            previous_session.SessionStatusChanged(previous_token);
-        } catch (const std::exception& ex) {
-            SIMPLEBLE_LOG_WARN(fmt::format("Failed to replace Windows client session handler: {}", ex.what()));
+            if (previous_token) {
+                previous_session.SessionStatusChanged(previous_token);
+            }
         } catch (...) {
-            SIMPLEBLE_LOG_WARN("Failed to replace Windows client session handler");
+        }
+        try {
+            previous_session.Close();
+        } catch (...) {
         }
     }
 
     auto weak_self = weak_from_this();
+    std::weak_ptr<RunState> weak_run = run;
     winrt::event_token token{};
     try {
-        token = session.SessionStatusChanged(
-            [weak_self, key, generation, sequence](const GattSession& sender,
-                                                   const GattSessionStatusChangedEventArgs& args) {
-                if (auto self = weak_self.lock()) {
-                    self->_on_session_status_changed(key, generation, sequence, sender, args);
+        token = session.SessionStatusChanged([weak_self, weak_run, key](const GattSession& sender,
+                                                                        const GattSessionStatusChangedEventArgs& args) {
+            const auto state = weak_run.lock();
+            if (!state || !state->active.load()) {
+                return;
+            }
+            if (auto self = weak_self.lock()) {
+                try {
+                    self->_on_session_status_changed(state, key, sender, args);
+                } catch (const std::exception& ex) {
+                    SIMPLEBLE_LOG_WARN(fmt::format("Failed to handle a Windows client session change: {}", ex.what()));
+                } catch (...) {
+                    SIMPLEBLE_LOG_WARN("Failed to handle a Windows client session change");
                 }
-            });
+            }
+        });
     } catch (...) {
         {
-            std::scoped_lock lock(_clients_mutex);
-            const auto it = _client_sessions.find(key);
-            if (it != _client_sessions.end() && it->second.generation == generation &&
-                it->second.sequence == sequence) {
-                _client_sessions.erase(it);
+            std::scoped_lock lock(run->clients_mutex);
+            const auto it = run->client_sessions.find(key);
+            if (it != run->client_sessions.end() && winrt::get_abi(it->second.session) == winrt::get_abi(session)) {
+                run->client_sessions.erase(it);
             }
+        }
+        try {
+            session.Close();
+        } catch (...) {
         }
         throw;
     }
 
+    GattSessionStatus status;
+    try {
+        status = session.SessionStatus();
+    } catch (...) {
+        {
+            std::scoped_lock lock(run->clients_mutex);
+            const auto it = run->client_sessions.find(key);
+            if (it != run->client_sessions.end() && winrt::get_abi(it->second.session) == winrt::get_abi(session)) {
+                run->client_sessions.erase(it);
+            }
+        }
+        try {
+            session.SessionStatusChanged(token);
+        } catch (...) {
+        }
+        try {
+            session.Close();
+        } catch (...) {
+        }
+        throw;
+    }
     bool keep_token = false;
+    bool close_session = false;
     bool notify_connected = false;
+    bool notify_disconnected = false;
     {
-        std::scoped_lock lock(_clients_mutex);
-        const auto it = _client_sessions.find(key);
-        if (_accepting_clients && _client_generation == generation && it != _client_sessions.end() &&
-            it->second.generation == generation && it->second.sequence == sequence) {
+        std::scoped_lock lock(run->clients_mutex);
+        const auto it = run->client_sessions.find(key);
+        if (run->active.load() && it != run->client_sessions.end() &&
+            winrt::get_abi(it->second.session) == winrt::get_abi(session)) {
             it->second.status_changed_token = token;
             keep_token = true;
-            const auto status = session.SessionStatus();
             if (status == GattSessionStatus::Active && !it->second.connected) {
                 it->second.connected = true;
                 notify_connected = true;
             } else if (status == GattSessionStatus::Closed) {
-                _client_sessions.erase(it);
+                notify_disconnected = it->second.connected;
+                run->client_sessions.erase(it);
                 keep_token = false;
+                close_session = true;
             }
         }
     }
@@ -392,24 +430,32 @@ void PeripheralWindows::_observe_session(const GattSession& session, uint64_t ex
         } catch (...) {
         }
     }
-    if (notify_connected && _active_client_generation() == generation) {
+    if (close_session) {
+        try {
+            session.Close();
+        } catch (...) {
+        }
+    }
+    if (notify_connected && run->active.load()) {
         SAFE_CALLBACK_CALL(_callback_on_client_connected, address);
+    } else if (notify_disconnected && run->active.load()) {
+        SAFE_CALLBACK_CALL(_callback_on_client_disconnected, address);
     }
 }
 
-void PeripheralWindows::_on_session_status_changed(const std::string& key, uint64_t generation, uint64_t sequence,
-                                                   const GattSession&, const GattSessionStatusChangedEventArgs& args) {
+void PeripheralWindows::_on_session_status_changed(const std::shared_ptr<RunState>& run, const std::string& key,
+                                                   const GattSession& sender,
+                                                   const GattSessionStatusChangedEventArgs& args) {
     BluetoothAddress address;
     GattSession session{nullptr};
     winrt::event_token token{};
     bool notify_connected = false;
     bool notify_disconnected = false;
-    bool revoke_token = false;
     {
-        std::scoped_lock lock(_clients_mutex);
-        const auto it = _client_sessions.find(key);
-        if (!_accepting_clients || _client_generation != generation || it == _client_sessions.end() ||
-            it->second.generation != generation || it->second.sequence != sequence) {
+        std::scoped_lock lock(run->clients_mutex);
+        const auto it = run->client_sessions.find(key);
+        if (!run->active.load() || it == run->client_sessions.end() ||
+            winrt::get_abi(it->second.session) != winrt::get_abi(sender)) {
             return;
         }
 
@@ -420,32 +466,40 @@ void PeripheralWindows::_on_session_status_changed(const std::string& key, uint6
         } else if (args.Status() == GattSessionStatus::Closed) {
             session = it->second.session;
             token = it->second.status_changed_token;
-            revoke_token = static_cast<bool>(token);
             notify_disconnected = it->second.connected;
-            _client_sessions.erase(it);
+            run->client_sessions.erase(it);
         }
     }
 
-    if (revoke_token) {
+    if (session) {
         try {
-            session.SessionStatusChanged(token);
+            if (token) {
+                session.SessionStatusChanged(token);
+            }
+        } catch (...) {
+        }
+        try {
+            session.Close();
         } catch (...) {
         }
     }
-    if (notify_connected && _active_client_generation() == generation) {
+    if (notify_connected && run->active.load()) {
         SAFE_CALLBACK_CALL(_callback_on_client_connected, address);
-    } else if (notify_disconnected && _active_client_generation() == generation) {
+    } else if (notify_disconnected && run->active.load()) {
         SAFE_CALLBACK_CALL(_callback_on_client_disconnected, address);
     }
 }
 
-void PeripheralWindows::_clear_client_sessions() noexcept {
+void PeripheralWindows::_clear_client_sessions(const std::shared_ptr<RunState>& run) noexcept {
+    if (!run) {
+        return;
+    }
+    run->active.store(false);
+
     std::map<std::string, ClientSession> sessions;
     {
-        std::scoped_lock lock(_clients_mutex);
-        _accepting_clients = false;
-        ++_client_generation;
-        sessions.swap(_client_sessions);
+        std::scoped_lock lock(run->clients_mutex);
+        sessions.swap(run->client_sessions);
     }
     for (auto& [key, client] : sessions) {
         try {
@@ -457,15 +511,14 @@ void PeripheralWindows::_clear_client_sessions() noexcept {
         } catch (...) {
             SIMPLEBLE_LOG_WARN("Failed to remove Windows client session handler");
         }
+        try {
+            client.session.Close();
+        } catch (const std::exception& ex) {
+            SIMPLEBLE_LOG_WARN(fmt::format("Failed to close Windows client session: {}", ex.what()));
+        } catch (...) {
+            SIMPLEBLE_LOG_WARN("Failed to close Windows client session");
+        }
     }
-}
-
-uint64_t PeripheralWindows::_active_client_generation() {
-    std::scoped_lock lock(_clients_mutex);
-    if (!_accepting_clients) {
-        return 0;
-    }
-    return _client_generation;
 }
 
 std::pair<std::string, BluetoothAddress> PeripheralWindows::_session_identity(const GattSession& session) {

--- a/simpleble/src/backends/windows/LocalPeripheralWindows.cpp
+++ b/simpleble/src/backends/windows/LocalPeripheralWindows.cpp
@@ -82,7 +82,6 @@ std::shared_ptr<ServiceBase> PeripheralWindows::add_service(BluetoothUUID uuid) 
             }
             return false;
         });
-    service->initialize_handlers();
     _services.push_back(service);
     return service;
 }
@@ -161,30 +160,39 @@ void PeripheralWindows::start() {
 
     bool rollback_failed = false;
     try {
-        WinRT::MtaManager::get().execute_sync([&publication_order, &rollback_failed]() {
-            size_t started_count = 0;
-            try {
+        size_t started_count = 0;
+        try {
+            WinRT::MtaManager::get().execute_sync([&publication_order, &started_count, generation]() {
                 for (const auto& service : publication_order) {
                     // WinRT publishes each primary GATT service through its own provider. Starting every provider
                     // keeps the complete GATT table available. Windows owns the shared advertisement payload and may
                     // omit UUIDs that do not fit, reporting StartedWithoutAllAdvertisementData for those providers.
-                    service->start_advertising();
+                    service->start_advertising(generation);
                     ++started_count;
                 }
-                for (size_t index = 0; index < started_count; ++index) {
-                    publication_order[index]->wait_until_advertising();
-                }
-            } catch (...) {
-                for (size_t index = 0; index < started_count; ++index) {
-                    try {
-                        publication_order[index]->stop_advertising();
-                    } catch (...) {
-                        rollback_failed = true;
-                    }
-                }
-                throw;
+            });
+            // Wait on the calling thread so the process-wide MTA executor remains available to scanning, GATT I/O,
+            // notifications, and status events while Windows finishes publishing the providers.
+            for (size_t index = 0; index < started_count; ++index) {
+                publication_order[index]->wait_until_advertising(generation);
             }
-        });
+        } catch (...) {
+            const auto start_error = std::current_exception();
+            try {
+                WinRT::MtaManager::get().execute_sync([&publication_order, &rollback_failed, started_count]() {
+                    for (size_t index = 0; index < started_count; ++index) {
+                        try {
+                            publication_order[index]->stop_advertising();
+                        } catch (...) {
+                            rollback_failed = true;
+                        }
+                    }
+                });
+            } catch (...) {
+                rollback_failed = true;
+            }
+            std::rethrow_exception(start_error);
+        }
         {
             std::scoped_lock clients_lock(_clients_mutex);
             _started.store(true);
@@ -204,7 +212,8 @@ void PeripheralWindows::start() {
         _cleanup_required = rollback_failed;
         if (rollback_failed) {
             SIMPLEBLE_LOG_ERROR(
-                "Failed to roll back every Windows local service; the peripheral remains frozen until stop() succeeds.");
+                "Failed to roll back every Windows local service; the peripheral remains frozen until stop() "
+                "succeeds.");
         }
         SIMPLEBLE_LOG_ERROR(fmt::format("Failed to start Windows local peripheral: {}", ex.what()));
         throw;
@@ -220,7 +229,8 @@ void PeripheralWindows::start() {
         _cleanup_required = rollback_failed;
         if (rollback_failed) {
             SIMPLEBLE_LOG_ERROR(
-                "Failed to roll back every Windows local service; the peripheral remains frozen until stop() succeeds.");
+                "Failed to roll back every Windows local service; the peripheral remains frozen until stop() "
+                "succeeds.");
         }
         SIMPLEBLE_LOG_ERROR("Failed to start Windows local peripheral");
         throw;
@@ -243,12 +253,10 @@ void PeripheralWindows::start() {
         try {
             stop();
         } catch (const std::exception& ex) {
-            SIMPLEBLE_LOG_ERROR(
-                fmt::format("Failed to roll back Windows local peripheral after callback scheduling failed: {}",
-                            ex.what()));
+            SIMPLEBLE_LOG_ERROR(fmt::format(
+                "Failed to roll back Windows local peripheral after callback scheduling failed: {}", ex.what()));
         } catch (...) {
-            SIMPLEBLE_LOG_ERROR(
-                "Failed to roll back Windows local peripheral after callback scheduling failed");
+            SIMPLEBLE_LOG_ERROR("Failed to roll back Windows local peripheral after callback scheduling failed");
         }
         std::rethrow_exception(schedule_error);
     }
@@ -440,8 +448,7 @@ void PeripheralWindows::_observe_session(const GattSession& session, uint64_t ex
 }
 
 void PeripheralWindows::_on_session_status_changed(const std::string& key, uint64_t generation, uint64_t sequence,
-                                                   const GattSession&,
-                                                   const GattSessionStatusChangedEventArgs& args) {
+                                                   const GattSession&, const GattSessionStatusChangedEventArgs& args) {
     BluetoothAddress address;
     GattSession session{nullptr};
     winrt::event_token token{};
@@ -556,9 +563,8 @@ void PeripheralWindows::_deliver_client_connected(const std::string& key, uint64
     {
         std::scoped_lock lock(_clients_mutex);
         const auto it = _client_sessions.find(key);
-        if (!_started.load() || !_accepting_clients || !_client_callbacks_enabled ||
-            _client_generation != generation || it == _client_sessions.end() ||
-            it->second.generation != generation || it->second.sequence != sequence ||
+        if (!_started.load() || !_accepting_clients || !_client_callbacks_enabled || _client_generation != generation ||
+            it == _client_sessions.end() || it->second.generation != generation || it->second.sequence != sequence ||
             !it->second.connect_callback_pending || it->second.connect_callback_in_progress) {
             return;
         }
@@ -600,14 +606,13 @@ void PeripheralWindows::_deliver_client_connected(const std::string& key, uint64
 }
 
 void PeripheralWindows::_deliver_client_disconnected(const std::string& key, uint64_t generation, uint64_t sequence,
-                                                      const BluetoothAddress& address) {
+                                                     const BluetoothAddress& address) {
     {
         std::scoped_lock lock(_clients_mutex);
         const auto state = _client_callback_states.find(key);
-        if (!_started.load() || !_accepting_clients || !_client_callbacks_enabled ||
-            _client_generation != generation || state == _client_callback_states.end() ||
-            state->second.connected_sequence != sequence || state->second.disconnect_sequence != sequence ||
-            state->second.disconnect_callback_in_progress) {
+        if (!_started.load() || !_accepting_clients || !_client_callbacks_enabled || _client_generation != generation ||
+            state == _client_callback_states.end() || state->second.connected_sequence != sequence ||
+            state->second.disconnect_sequence != sequence || state->second.disconnect_callback_in_progress) {
             return;
         }
         state->second.disconnect_callback_in_progress = true;

--- a/simpleble/src/backends/windows/LocalPeripheralWindows.cpp
+++ b/simpleble/src/backends/windows/LocalPeripheralWindows.cpp
@@ -357,23 +357,11 @@ void PeripheralWindows::_observe_session(const GattSession& session, uint64_t ex
             return;
         }
         generation = _client_generation;
-        const auto existing = _client_sessions.find(key);
-        if (existing != _client_sessions.end()) {
-            if (existing->second.closed || winrt::get_abi(existing->second.session) != winrt::get_abi(session)) {
-                _pending_client_sessions.insert_or_assign(key, PendingClientSession{session, generation});
-            }
-            return;
-        }
-        const auto callback_state = _client_callback_states.find(key);
-        if (callback_state != _client_callback_states.end() &&
-            (callback_state->second.disconnect_sequence != 0 ||
-             callback_state->second.disconnect_callback_in_progress)) {
-            _pending_client_sessions.insert_or_assign(key, PendingClientSession{session, generation});
+        if (_client_sessions.count(key) != 0) {
             return;
         }
         sequence = ++_next_client_sequence;
-        _client_sessions.emplace(
-            key, ClientSession{session, {}, address, false, false, false, false, false, generation, sequence});
+        _client_sessions.emplace(key, ClientSession{session, {}, address, false, generation, sequence});
     }
 
     auto weak_self = weak_from_this();
@@ -395,14 +383,11 @@ void PeripheralWindows::_observe_session(const GattSession& session, uint64_t ex
                 _client_sessions.erase(it);
             }
         }
-        _promote_pending_client_session(key, generation);
         throw;
     }
 
     bool keep_token = false;
-    bool deliver_connected = false;
-    bool deliver_disconnected = false;
-    bool promote_pending = false;
+    bool notify_connected = false;
     {
         std::scoped_lock lock(_clients_mutex);
         const auto it = _client_sessions.find(key);
@@ -413,20 +398,11 @@ void PeripheralWindows::_observe_session(const GattSession& session, uint64_t ex
             const auto status = session.SessionStatus();
             if (status == GattSessionStatus::Active && !it->second.connected) {
                 it->second.connected = true;
-                it->second.connect_callback_pending = true;
-                deliver_connected = true;
-            } else if (status == GattSessionStatus::Closed) {
-                if (it->second.connect_callback_pending) {
-                    it->second.closed = true;
-                    it->second.status_changed_token = {};
-                } else {
-                    deliver_disconnected = it->second.connected_notified;
-                    if (deliver_disconnected) {
-                        _client_callback_states[key].disconnect_sequence = sequence;
-                    }
-                    _client_sessions.erase(it);
-                    promote_pending = !deliver_disconnected;
+                if (_started.load() && _client_callbacks_enabled) {
+                    notify_connected = true;
                 }
+            } else if (status == GattSessionStatus::Closed) {
+                _client_sessions.erase(it);
                 keep_token = false;
             }
         }
@@ -438,12 +414,8 @@ void PeripheralWindows::_observe_session(const GattSession& session, uint64_t ex
         } catch (...) {
         }
     }
-    if (deliver_connected) {
-        _deliver_client_connected(key, generation, sequence);
-    } else if (deliver_disconnected) {
-        _deliver_client_disconnected(key, generation, sequence, address);
-    } else if (promote_pending) {
-        _promote_pending_client_session(key, generation);
+    if (notify_connected) {
+        SAFE_CALLBACK_CALL(_callback_on_client_connected, address);
     }
 }
 
@@ -452,9 +424,8 @@ void PeripheralWindows::_on_session_status_changed(const std::string& key, uint6
     BluetoothAddress address;
     GattSession session{nullptr};
     winrt::event_token token{};
-    bool deliver_connected = false;
-    bool deliver_disconnected = false;
-    bool promote_pending = false;
+    bool notify_connected = false;
+    bool notify_disconnected = false;
     bool revoke_token = false;
     {
         std::scoped_lock lock(_clients_mutex);
@@ -467,23 +438,15 @@ void PeripheralWindows::_on_session_status_changed(const std::string& key, uint6
         address = it->second.address;
         if (args.Status() == GattSessionStatus::Active && !it->second.connected) {
             it->second.connected = true;
-            it->second.connect_callback_pending = true;
-            deliver_connected = true;
+            if (_started.load() && _client_callbacks_enabled) {
+                notify_connected = true;
+            }
         } else if (args.Status() == GattSessionStatus::Closed) {
             session = it->second.session;
             token = it->second.status_changed_token;
             revoke_token = static_cast<bool>(token);
-            it->second.status_changed_token = {};
-            if (it->second.connect_callback_pending) {
-                it->second.closed = true;
-            } else {
-                deliver_disconnected = it->second.connected_notified;
-                if (deliver_disconnected) {
-                    _client_callback_states[key].disconnect_sequence = sequence;
-                }
-                _client_sessions.erase(it);
-                promote_pending = !deliver_disconnected;
-            }
+            notify_disconnected = it->second.connected && _started.load() && _client_callbacks_enabled;
+            _client_sessions.erase(it);
         }
     }
 
@@ -493,12 +456,10 @@ void PeripheralWindows::_on_session_status_changed(const std::string& key, uint6
         } catch (...) {
         }
     }
-    if (deliver_connected) {
-        _deliver_client_connected(key, generation, sequence);
-    } else if (deliver_disconnected) {
-        _deliver_client_disconnected(key, generation, sequence, address);
-    } else if (promote_pending) {
-        _promote_pending_client_session(key, generation);
+    if (notify_connected) {
+        SAFE_CALLBACK_CALL(_callback_on_client_connected, address);
+    } else if (notify_disconnected) {
+        SAFE_CALLBACK_CALL(_callback_on_client_disconnected, address);
     }
 }
 
@@ -510,8 +471,6 @@ void PeripheralWindows::_clear_client_sessions() noexcept {
         _client_callbacks_enabled = false;
         ++_client_generation;
         sessions.swap(_client_sessions);
-        _client_callback_states.clear();
-        _pending_client_sessions.clear();
     }
     for (auto& [key, client] : sessions) {
         try {
@@ -540,7 +499,7 @@ bool PeripheralWindows::_client_callbacks_are_enabled(uint64_t generation) {
 }
 
 void PeripheralWindows::_enable_client_callbacks(uint64_t generation) {
-    std::vector<std::pair<std::string, uint64_t>> pending_connections;
+    std::vector<BluetoothAddress> connected_clients;
     {
         std::scoped_lock lock(_clients_mutex);
         if (!_started.load() || !_accepting_clients || _client_generation != generation) {
@@ -548,112 +507,13 @@ void PeripheralWindows::_enable_client_callbacks(uint64_t generation) {
         }
         _client_callbacks_enabled = true;
         for (const auto& [key, client] : _client_sessions) {
-            if (client.generation == generation && client.connect_callback_pending) {
-                pending_connections.emplace_back(key, client.sequence);
+            if (client.generation == generation && client.connected) {
+                connected_clients.push_back(client.address);
             }
         }
     }
-    for (const auto& [key, sequence] : pending_connections) {
-        _deliver_client_connected(key, generation, sequence);
-    }
-}
-
-void PeripheralWindows::_deliver_client_connected(const std::string& key, uint64_t generation, uint64_t sequence) {
-    BluetoothAddress address;
-    {
-        std::scoped_lock lock(_clients_mutex);
-        const auto it = _client_sessions.find(key);
-        if (!_started.load() || !_accepting_clients || !_client_callbacks_enabled || _client_generation != generation ||
-            it == _client_sessions.end() || it->second.generation != generation || it->second.sequence != sequence ||
-            !it->second.connect_callback_pending || it->second.connect_callback_in_progress) {
-            return;
-        }
-        const auto callback_state = _client_callback_states.find(key);
-        if (callback_state != _client_callback_states.end() &&
-            (callback_state->second.disconnect_sequence != 0 ||
-             callback_state->second.disconnect_callback_in_progress)) {
-            return;
-        }
-        address = it->second.address;
-        it->second.connect_callback_in_progress = true;
-    }
-
-    SAFE_CALLBACK_CALL(_callback_on_client_connected, address);
-
-    bool deliver_disconnected = false;
-    {
-        std::scoped_lock lock(_clients_mutex);
-        const auto it = _client_sessions.find(key);
-        if (!_accepting_clients || _client_generation != generation || it == _client_sessions.end() ||
-            it->second.generation != generation || it->second.sequence != sequence ||
-            !it->second.connect_callback_pending || !it->second.connect_callback_in_progress) {
-            return;
-        }
-        it->second.connect_callback_pending = false;
-        it->second.connect_callback_in_progress = false;
-        it->second.connected_notified = true;
-        _client_callback_states[key].connected_sequence = sequence;
-        if (it->second.closed) {
-            _client_sessions.erase(it);
-            _client_callback_states[key].disconnect_sequence = sequence;
-            deliver_disconnected = true;
-        }
-    }
-
-    if (deliver_disconnected) {
-        _deliver_client_disconnected(key, generation, sequence, address);
-    }
-}
-
-void PeripheralWindows::_deliver_client_disconnected(const std::string& key, uint64_t generation, uint64_t sequence,
-                                                     const BluetoothAddress& address) {
-    {
-        std::scoped_lock lock(_clients_mutex);
-        const auto state = _client_callback_states.find(key);
-        if (!_started.load() || !_accepting_clients || !_client_callbacks_enabled || _client_generation != generation ||
-            state == _client_callback_states.end() || state->second.connected_sequence != sequence ||
-            state->second.disconnect_sequence != sequence || state->second.disconnect_callback_in_progress) {
-            return;
-        }
-        state->second.disconnect_callback_in_progress = true;
-    }
-    SAFE_CALLBACK_CALL(_callback_on_client_disconnected, address);
-
-    {
-        std::scoped_lock lock(_clients_mutex);
-        const auto state = _client_callback_states.find(key);
-        if (!_accepting_clients || _client_generation != generation || state == _client_callback_states.end() ||
-            state->second.disconnect_sequence != sequence) {
-            return;
-        }
-        state->second.connected_sequence = 0;
-        state->second.disconnect_sequence = 0;
-        state->second.disconnect_callback_in_progress = false;
-
-        _client_callback_states.erase(state);
-    }
-    _promote_pending_client_session(key, generation);
-}
-
-void PeripheralWindows::_promote_pending_client_session(const std::string& key, uint64_t generation) {
-    GattSession session{nullptr};
-    {
-        std::scoped_lock lock(_clients_mutex);
-        const auto pending = _pending_client_sessions.find(key);
-        if (!_accepting_clients || _client_generation != generation || _client_sessions.count(key) != 0 ||
-            pending == _pending_client_sessions.end() || pending->second.generation != generation) {
-            return;
-        }
-        session = pending->second.session;
-        _pending_client_sessions.erase(pending);
-    }
-
-    try {
-        _observe_session(session, generation);
-    } catch (const std::exception& ex) {
-        SIMPLEBLE_LOG_WARN(fmt::format("Failed to promote a Windows local peripheral client: {}", ex.what()));
-    } catch (...) {
-        SIMPLEBLE_LOG_WARN("Failed to promote a Windows local peripheral client");
+    for (const auto& address : connected_clients) {
+        SAFE_CALLBACK_CALL(_callback_on_client_connected, address);
     }
 }
 

--- a/simpleble/src/backends/windows/LocalPeripheralWindows.cpp
+++ b/simpleble/src/backends/windows/LocalPeripheralWindows.cpp
@@ -351,17 +351,36 @@ void PeripheralWindows::_observe_session(const GattSession& session, uint64_t ex
     const auto [key, address] = _session_identity(session);
     uint64_t generation;
     uint64_t sequence;
+    GattSession previous_session{nullptr};
+    winrt::event_token previous_token{};
     {
         std::scoped_lock lock(_clients_mutex);
         if (!_accepting_clients || (expected_generation != 0 && _client_generation != expected_generation)) {
             return;
         }
         generation = _client_generation;
-        if (_client_sessions.count(key) != 0) {
+        const auto existing = _client_sessions.find(key);
+        if (existing != _client_sessions.end() && winrt::get_abi(existing->second.session) == winrt::get_abi(session)) {
             return;
         }
         sequence = ++_next_client_sequence;
-        _client_sessions.emplace(key, ClientSession{session, {}, address, false, generation, sequence});
+        if (existing == _client_sessions.end()) {
+            _client_sessions.emplace(key, ClientSession{session, {}, address, false, generation, sequence});
+        } else {
+            previous_session = existing->second.session;
+            previous_token = existing->second.status_changed_token;
+            existing->second = ClientSession{session, {}, address, existing->second.connected, generation, sequence};
+        }
+    }
+
+    if (previous_session && previous_token) {
+        try {
+            previous_session.SessionStatusChanged(previous_token);
+        } catch (const std::exception& ex) {
+            SIMPLEBLE_LOG_WARN(fmt::format("Failed to replace Windows client session handler: {}", ex.what()));
+        } catch (...) {
+            SIMPLEBLE_LOG_WARN("Failed to replace Windows client session handler");
+        }
     }
 
     auto weak_self = weak_from_this();
@@ -414,7 +433,7 @@ void PeripheralWindows::_observe_session(const GattSession& session, uint64_t ex
         } catch (...) {
         }
     }
-    if (notify_connected) {
+    if (notify_connected && _client_callbacks_are_enabled(generation)) {
         SAFE_CALLBACK_CALL(_callback_on_client_connected, address);
     }
 }
@@ -456,9 +475,9 @@ void PeripheralWindows::_on_session_status_changed(const std::string& key, uint6
         } catch (...) {
         }
     }
-    if (notify_connected) {
+    if (notify_connected && _client_callbacks_are_enabled(generation)) {
         SAFE_CALLBACK_CALL(_callback_on_client_connected, address);
-    } else if (notify_disconnected) {
+    } else if (notify_disconnected && _client_callbacks_are_enabled(generation)) {
         SAFE_CALLBACK_CALL(_callback_on_client_disconnected, address);
     }
 }
@@ -513,7 +532,9 @@ void PeripheralWindows::_enable_client_callbacks(uint64_t generation) {
         }
     }
     for (const auto& address : connected_clients) {
-        SAFE_CALLBACK_CALL(_callback_on_client_connected, address);
+        if (_client_callbacks_are_enabled(generation)) {
+            SAFE_CALLBACK_CALL(_callback_on_client_connected, address);
+        }
     }
 }
 

--- a/simpleble/src/backends/windows/LocalPeripheralWindows.cpp
+++ b/simpleble/src/backends/windows/LocalPeripheralWindows.cpp
@@ -1,0 +1,664 @@
+#include "LocalPeripheralWindows.h"
+
+#include <algorithm>
+#include <exception>
+#include <utility>
+
+#include <simpleble/Exceptions.h>
+
+#include "CommonUtils.h"
+#include "LocalServiceWindows.h"
+#include "LoggingInternal.h"
+#include "MtaManager.h"
+#include "Utils.h"
+#include "winrt/Windows.Foundation.Metadata.h"
+#include "winrt/Windows.System.Threading.h"
+
+namespace SimpleBLE::Local {
+
+using namespace winrt::Windows::Devices::Bluetooth::GenericAttributeProfile;
+
+PeripheralWindows::PeripheralWindows(winrt::Windows::Devices::Bluetooth::BluetoothAdapter adapter)
+    : _adapter(std::move(adapter)) {}
+
+PeripheralWindows::~PeripheralWindows() {
+    _callback_on_client_connected.unload();
+    _callback_on_client_disconnected.unload();
+    try {
+        stop();
+    } catch (const std::exception& ex) {
+        SIMPLEBLE_LOG_WARN(fmt::format("Failed to stop Windows local peripheral during cleanup: {}", ex.what()));
+    } catch (...) {
+        SIMPLEBLE_LOG_WARN("Failed to stop Windows local peripheral during cleanup");
+    }
+
+    std::scoped_lock lock(_lifecycle_mutex);
+    _services.clear();
+}
+
+void* PeripheralWindows::underlying() const {
+    return reinterpret_cast<void*>(const_cast<winrt::Windows::Devices::Bluetooth::BluetoothAdapter*>(&_adapter));
+}
+
+Advertisement PeripheralWindows::advertisement() {
+    std::scoped_lock lock(_lifecycle_mutex);
+    return _advertisement;
+}
+
+void PeripheralWindows::set_advertisement(Advertisement advertisement) {
+    std::scoped_lock lock(_lifecycle_mutex);
+    _ensure_mutable();
+    _advertisement = std::move(advertisement);
+}
+
+std::shared_ptr<ServiceBase> PeripheralWindows::add_service(BluetoothUUID uuid) {
+    std::scoped_lock lock(_lifecycle_mutex);
+    _ensure_mutable();
+
+    auto weak_self = weak_from_this();
+    auto service = std::make_shared<ServiceWindows>(
+        std::move(uuid),
+        [weak_self](const GattSession& session, uint64_t expected_generation) {
+            if (auto self = weak_self.lock()) {
+                try {
+                    self->_observe_session(session, expected_generation);
+                } catch (const std::exception& ex) {
+                    SIMPLEBLE_LOG_WARN(
+                        fmt::format("Failed to observe a Windows local peripheral client: {}", ex.what()));
+                } catch (...) {
+                    SIMPLEBLE_LOG_WARN("Failed to observe a Windows local peripheral client");
+                }
+            }
+        },
+        [weak_self]() -> uint64_t {
+            if (auto self = weak_self.lock()) {
+                return self->_active_client_generation();
+            }
+            return 0;
+        },
+        [weak_self](uint64_t generation) {
+            if (auto self = weak_self.lock()) {
+                return self->_client_callbacks_are_enabled(generation);
+            }
+            return false;
+        });
+    service->initialize_handlers();
+    _services.push_back(service);
+    return service;
+}
+
+std::vector<std::shared_ptr<ServiceBase>> PeripheralWindows::services() {
+    std::scoped_lock lock(_lifecycle_mutex);
+    return {_services.begin(), _services.end()};
+}
+
+void PeripheralWindows::remove_all_services() {
+    std::scoped_lock lock(_lifecycle_mutex);
+    _ensure_mutable();
+    _services.clear();
+}
+
+void PeripheralWindows::start() {
+    std::unique_lock lock(_lifecycle_mutex);
+    if (_cleanup_required) {
+        throw Exception::OperationFailed(
+            "The previous Windows peripheral operation requires cleanup; call stop() before starting again.");
+    }
+    if (_started.load()) {
+        return;
+    }
+    if (_services.empty()) {
+        throw Exception::OperationFailed("Windows peripheral mode requires at least one local service.");
+    }
+    if (!winrt::Windows::Foundation::Metadata::ApiInformation::IsPropertyPresent(
+            L"Windows.Devices.Bluetooth.BluetoothAdapter", L"IsPeripheralRoleSupported") ||
+        !_adapter.IsPeripheralRoleSupported()) {
+        throw Exception::OperationNotSupported();
+    }
+
+    if (_advertisement.local_name.has_value()) {
+        SIMPLEBLE_LOG_WARN(
+            "Windows peripheral mode uses the system Bluetooth name; the requested local advertisement name cannot be "
+            "applied.");
+    }
+
+    std::vector<std::shared_ptr<ServiceWindows>> publication_order;
+    publication_order.reserve(_services.size());
+    for (const auto& requested_uuid : _advertisement.service_uuids) {
+        const auto requested_guid = uuid_to_guid(requested_uuid);
+        const auto service = std::find_if(_services.begin(), _services.end(), [&](const auto& candidate) {
+            return uuid_to_guid(candidate->uuid()) == requested_guid;
+        });
+        if (service == _services.end()) {
+            throw Exception::OperationFailed(
+                fmt::format("Advertisement service UUID {} is not hosted by this local peripheral.", requested_uuid));
+        }
+        if (std::find(publication_order.begin(), publication_order.end(), *service) == publication_order.end()) {
+            publication_order.push_back(*service);
+        }
+    }
+    for (const auto& service : _services) {
+        if (std::find(publication_order.begin(), publication_order.end(), service) == publication_order.end()) {
+            publication_order.push_back(service);
+        }
+    }
+
+    const auto services_snapshot = _services;
+    for (const auto& service : services_snapshot) {
+        service->freeze();
+    }
+
+    uint64_t generation;
+    {
+        std::scoped_lock clients_lock(_clients_mutex);
+        generation = ++_client_generation;
+        _accepting_clients = true;
+        _client_callbacks_enabled = false;
+    }
+    for (const auto& service : services_snapshot) {
+        service->activate(generation);
+    }
+
+    bool rollback_failed = false;
+    try {
+        WinRT::MtaManager::get().execute_sync([&publication_order, &rollback_failed]() {
+            size_t started_count = 0;
+            try {
+                for (const auto& service : publication_order) {
+                    // WinRT publishes each primary GATT service through its own provider. Starting every provider
+                    // keeps the complete GATT table available. Windows owns the shared advertisement payload and may
+                    // omit UUIDs that do not fit, reporting StartedWithoutAllAdvertisementData for those providers.
+                    service->start_advertising();
+                    ++started_count;
+                }
+                for (size_t index = 0; index < started_count; ++index) {
+                    publication_order[index]->wait_until_advertising();
+                }
+            } catch (...) {
+                for (size_t index = 0; index < started_count; ++index) {
+                    try {
+                        publication_order[index]->stop_advertising();
+                    } catch (...) {
+                        rollback_failed = true;
+                    }
+                }
+                throw;
+            }
+        });
+        {
+            std::scoped_lock clients_lock(_clients_mutex);
+            _started.store(true);
+        }
+        for (const auto& service : services_snapshot) {
+            service->reconcile_subscriptions(generation);
+        }
+    } catch (const std::exception& ex) {
+        _clear_client_sessions();
+        for (const auto& service : services_snapshot) {
+            service->deactivate();
+            service->reset_subscriptions();
+            if (!rollback_failed) {
+                service->unfreeze();
+            }
+        }
+        _cleanup_required = rollback_failed;
+        if (rollback_failed) {
+            SIMPLEBLE_LOG_ERROR(
+                "Failed to roll back every Windows local service; the peripheral remains frozen until stop() succeeds.");
+        }
+        SIMPLEBLE_LOG_ERROR(fmt::format("Failed to start Windows local peripheral: {}", ex.what()));
+        throw;
+    } catch (...) {
+        _clear_client_sessions();
+        for (const auto& service : services_snapshot) {
+            service->deactivate();
+            service->reset_subscriptions();
+            if (!rollback_failed) {
+                service->unfreeze();
+            }
+        }
+        _cleanup_required = rollback_failed;
+        if (rollback_failed) {
+            SIMPLEBLE_LOG_ERROR(
+                "Failed to roll back every Windows local service; the peripheral remains frozen until stop() succeeds.");
+        }
+        SIMPLEBLE_LOG_ERROR("Failed to start Windows local peripheral");
+        throw;
+    }
+
+    lock.unlock();
+    auto weak_self = weak_from_this();
+    try {
+        winrt::Windows::System::Threading::ThreadPool::RunAsync(
+            [weak_self, generation, services_snapshot](const winrt::Windows::Foundation::IAsyncAction&) {
+                if (auto self = weak_self.lock()) {
+                    self->_enable_client_callbacks(generation);
+                    for (const auto& service : services_snapshot) {
+                        service->enable_subscription_callbacks(generation);
+                    }
+                }
+            });
+    } catch (...) {
+        const auto schedule_error = std::current_exception();
+        try {
+            stop();
+        } catch (const std::exception& ex) {
+            SIMPLEBLE_LOG_ERROR(
+                fmt::format("Failed to roll back Windows local peripheral after callback scheduling failed: {}",
+                            ex.what()));
+        } catch (...) {
+            SIMPLEBLE_LOG_ERROR(
+                "Failed to roll back Windows local peripheral after callback scheduling failed");
+        }
+        std::rethrow_exception(schedule_error);
+    }
+}
+
+void PeripheralWindows::stop() {
+    std::scoped_lock lock(_lifecycle_mutex);
+    if (!_started.load() && !_cleanup_required) {
+        return;
+    }
+
+    _clear_client_sessions();
+    for (const auto& service : _services) {
+        service->deactivate();
+        service->reset_subscriptions();
+    }
+
+    std::exception_ptr first_error;
+    try {
+        WinRT::MtaManager::get().execute_sync([this]() {
+            std::exception_ptr stop_error;
+            for (const auto& service : _services) {
+                try {
+                    service->stop_advertising();
+                } catch (...) {
+                    if (!stop_error) {
+                        stop_error = std::current_exception();
+                    }
+                }
+            }
+            if (stop_error) {
+                std::rethrow_exception(stop_error);
+            }
+        });
+    } catch (...) {
+        first_error = std::current_exception();
+    }
+
+    if (first_error) {
+        _cleanup_required = true;
+        std::rethrow_exception(first_error);
+    }
+
+    for (const auto& service : _services) {
+        service->unfreeze();
+    }
+    _started.store(false);
+    _cleanup_required = false;
+}
+
+bool PeripheralWindows::is_started() { return _started.load(); }
+
+bool PeripheralWindows::is_advertising() {
+    std::scoped_lock lock(_lifecycle_mutex);
+    if (!_started.load() && !_cleanup_required) {
+        return false;
+    }
+    return WinRT::MtaManager::get().execute_sync<bool>([this]() {
+        return std::all_of(_services.begin(), _services.end(),
+                           [](const auto& service) { return service->is_advertising(); });
+    });
+}
+
+void PeripheralWindows::set_callback_on_client_connected(std::function<void(BluetoothAddress)> on_client_connected) {
+    if (on_client_connected) {
+        _callback_on_client_connected.load(std::move(on_client_connected));
+    } else {
+        _callback_on_client_connected.unload();
+    }
+}
+
+void PeripheralWindows::set_callback_on_client_disconnected(
+    std::function<void(BluetoothAddress)> on_client_disconnected) {
+    if (on_client_disconnected) {
+        _callback_on_client_disconnected.load(std::move(on_client_disconnected));
+    } else {
+        _callback_on_client_disconnected.unload();
+    }
+}
+
+void PeripheralWindows::_ensure_mutable() const {
+    if (_started.load() || _cleanup_required) {
+        throw Exception::OperationFailed("The local peripheral cannot be changed while it is started.");
+    }
+}
+
+void PeripheralWindows::_observe_session(const GattSession& session, uint64_t expected_generation) {
+    if (!session) {
+        return;
+    }
+
+    const auto [key, address] = _session_identity(session);
+    uint64_t generation;
+    uint64_t sequence;
+    {
+        std::scoped_lock lock(_clients_mutex);
+        if (!_accepting_clients || (expected_generation != 0 && _client_generation != expected_generation)) {
+            return;
+        }
+        generation = _client_generation;
+        const auto existing = _client_sessions.find(key);
+        if (existing != _client_sessions.end()) {
+            if (existing->second.closed || winrt::get_abi(existing->second.session) != winrt::get_abi(session)) {
+                _pending_client_sessions.insert_or_assign(key, PendingClientSession{session, generation});
+            }
+            return;
+        }
+        const auto callback_state = _client_callback_states.find(key);
+        if (callback_state != _client_callback_states.end() &&
+            (callback_state->second.disconnect_sequence != 0 ||
+             callback_state->second.disconnect_callback_in_progress)) {
+            _pending_client_sessions.insert_or_assign(key, PendingClientSession{session, generation});
+            return;
+        }
+        sequence = ++_next_client_sequence;
+        _client_sessions.emplace(
+            key, ClientSession{session, {}, address, false, false, false, false, false, generation, sequence});
+    }
+
+    auto weak_self = weak_from_this();
+    winrt::event_token token{};
+    try {
+        token = session.SessionStatusChanged(
+            [weak_self, key, generation, sequence](const GattSession& sender,
+                                                   const GattSessionStatusChangedEventArgs& args) {
+                if (auto self = weak_self.lock()) {
+                    self->_on_session_status_changed(key, generation, sequence, sender, args);
+                }
+            });
+    } catch (...) {
+        {
+            std::scoped_lock lock(_clients_mutex);
+            const auto it = _client_sessions.find(key);
+            if (it != _client_sessions.end() && it->second.generation == generation &&
+                it->second.sequence == sequence) {
+                _client_sessions.erase(it);
+            }
+        }
+        _promote_pending_client_session(key, generation);
+        throw;
+    }
+
+    bool keep_token = false;
+    bool deliver_connected = false;
+    bool deliver_disconnected = false;
+    bool promote_pending = false;
+    {
+        std::scoped_lock lock(_clients_mutex);
+        const auto it = _client_sessions.find(key);
+        if (_accepting_clients && _client_generation == generation && it != _client_sessions.end() &&
+            it->second.generation == generation && it->second.sequence == sequence) {
+            it->second.status_changed_token = token;
+            keep_token = true;
+            const auto status = session.SessionStatus();
+            if (status == GattSessionStatus::Active && !it->second.connected) {
+                it->second.connected = true;
+                it->second.connect_callback_pending = true;
+                deliver_connected = true;
+            } else if (status == GattSessionStatus::Closed) {
+                if (it->second.connect_callback_pending) {
+                    it->second.closed = true;
+                    it->second.status_changed_token = {};
+                } else {
+                    deliver_disconnected = it->second.connected_notified;
+                    if (deliver_disconnected) {
+                        _client_callback_states[key].disconnect_sequence = sequence;
+                    }
+                    _client_sessions.erase(it);
+                    promote_pending = !deliver_disconnected;
+                }
+                keep_token = false;
+            }
+        }
+    }
+
+    if (!keep_token) {
+        try {
+            session.SessionStatusChanged(token);
+        } catch (...) {
+        }
+    }
+    if (deliver_connected) {
+        _deliver_client_connected(key, generation, sequence);
+    } else if (deliver_disconnected) {
+        _deliver_client_disconnected(key, generation, sequence, address);
+    } else if (promote_pending) {
+        _promote_pending_client_session(key, generation);
+    }
+}
+
+void PeripheralWindows::_on_session_status_changed(const std::string& key, uint64_t generation, uint64_t sequence,
+                                                   const GattSession&,
+                                                   const GattSessionStatusChangedEventArgs& args) {
+    BluetoothAddress address;
+    GattSession session{nullptr};
+    winrt::event_token token{};
+    bool deliver_connected = false;
+    bool deliver_disconnected = false;
+    bool promote_pending = false;
+    bool revoke_token = false;
+    {
+        std::scoped_lock lock(_clients_mutex);
+        const auto it = _client_sessions.find(key);
+        if (!_accepting_clients || _client_generation != generation || it == _client_sessions.end() ||
+            it->second.generation != generation || it->second.sequence != sequence) {
+            return;
+        }
+
+        address = it->second.address;
+        if (args.Status() == GattSessionStatus::Active && !it->second.connected) {
+            it->second.connected = true;
+            it->second.connect_callback_pending = true;
+            deliver_connected = true;
+        } else if (args.Status() == GattSessionStatus::Closed) {
+            session = it->second.session;
+            token = it->second.status_changed_token;
+            revoke_token = static_cast<bool>(token);
+            it->second.status_changed_token = {};
+            if (it->second.connect_callback_pending) {
+                it->second.closed = true;
+            } else {
+                deliver_disconnected = it->second.connected_notified;
+                if (deliver_disconnected) {
+                    _client_callback_states[key].disconnect_sequence = sequence;
+                }
+                _client_sessions.erase(it);
+                promote_pending = !deliver_disconnected;
+            }
+        }
+    }
+
+    if (revoke_token) {
+        try {
+            session.SessionStatusChanged(token);
+        } catch (...) {
+        }
+    }
+    if (deliver_connected) {
+        _deliver_client_connected(key, generation, sequence);
+    } else if (deliver_disconnected) {
+        _deliver_client_disconnected(key, generation, sequence, address);
+    } else if (promote_pending) {
+        _promote_pending_client_session(key, generation);
+    }
+}
+
+void PeripheralWindows::_clear_client_sessions() noexcept {
+    std::map<std::string, ClientSession> sessions;
+    {
+        std::scoped_lock lock(_clients_mutex);
+        _accepting_clients = false;
+        _client_callbacks_enabled = false;
+        ++_client_generation;
+        sessions.swap(_client_sessions);
+        _client_callback_states.clear();
+        _pending_client_sessions.clear();
+    }
+    for (auto& [key, client] : sessions) {
+        try {
+            if (client.status_changed_token) {
+                client.session.SessionStatusChanged(client.status_changed_token);
+            }
+        } catch (const std::exception& ex) {
+            SIMPLEBLE_LOG_WARN(fmt::format("Failed to remove Windows client session handler: {}", ex.what()));
+        } catch (...) {
+            SIMPLEBLE_LOG_WARN("Failed to remove Windows client session handler");
+        }
+    }
+}
+
+uint64_t PeripheralWindows::_active_client_generation() {
+    std::scoped_lock lock(_clients_mutex);
+    if (!_accepting_clients) {
+        return 0;
+    }
+    return _client_generation;
+}
+
+bool PeripheralWindows::_client_callbacks_are_enabled(uint64_t generation) {
+    std::scoped_lock lock(_clients_mutex);
+    return _started.load() && _accepting_clients && _client_callbacks_enabled && _client_generation == generation;
+}
+
+void PeripheralWindows::_enable_client_callbacks(uint64_t generation) {
+    std::vector<std::pair<std::string, uint64_t>> pending_connections;
+    {
+        std::scoped_lock lock(_clients_mutex);
+        if (!_started.load() || !_accepting_clients || _client_generation != generation) {
+            return;
+        }
+        _client_callbacks_enabled = true;
+        for (const auto& [key, client] : _client_sessions) {
+            if (client.generation == generation && client.connect_callback_pending) {
+                pending_connections.emplace_back(key, client.sequence);
+            }
+        }
+    }
+    for (const auto& [key, sequence] : pending_connections) {
+        _deliver_client_connected(key, generation, sequence);
+    }
+}
+
+void PeripheralWindows::_deliver_client_connected(const std::string& key, uint64_t generation, uint64_t sequence) {
+    BluetoothAddress address;
+    {
+        std::scoped_lock lock(_clients_mutex);
+        const auto it = _client_sessions.find(key);
+        if (!_started.load() || !_accepting_clients || !_client_callbacks_enabled ||
+            _client_generation != generation || it == _client_sessions.end() ||
+            it->second.generation != generation || it->second.sequence != sequence ||
+            !it->second.connect_callback_pending || it->second.connect_callback_in_progress) {
+            return;
+        }
+        const auto callback_state = _client_callback_states.find(key);
+        if (callback_state != _client_callback_states.end() &&
+            (callback_state->second.disconnect_sequence != 0 ||
+             callback_state->second.disconnect_callback_in_progress)) {
+            return;
+        }
+        address = it->second.address;
+        it->second.connect_callback_in_progress = true;
+    }
+
+    SAFE_CALLBACK_CALL(_callback_on_client_connected, address);
+
+    bool deliver_disconnected = false;
+    {
+        std::scoped_lock lock(_clients_mutex);
+        const auto it = _client_sessions.find(key);
+        if (!_accepting_clients || _client_generation != generation || it == _client_sessions.end() ||
+            it->second.generation != generation || it->second.sequence != sequence ||
+            !it->second.connect_callback_pending || !it->second.connect_callback_in_progress) {
+            return;
+        }
+        it->second.connect_callback_pending = false;
+        it->second.connect_callback_in_progress = false;
+        it->second.connected_notified = true;
+        _client_callback_states[key].connected_sequence = sequence;
+        if (it->second.closed) {
+            _client_sessions.erase(it);
+            _client_callback_states[key].disconnect_sequence = sequence;
+            deliver_disconnected = true;
+        }
+    }
+
+    if (deliver_disconnected) {
+        _deliver_client_disconnected(key, generation, sequence, address);
+    }
+}
+
+void PeripheralWindows::_deliver_client_disconnected(const std::string& key, uint64_t generation, uint64_t sequence,
+                                                      const BluetoothAddress& address) {
+    {
+        std::scoped_lock lock(_clients_mutex);
+        const auto state = _client_callback_states.find(key);
+        if (!_started.load() || !_accepting_clients || !_client_callbacks_enabled ||
+            _client_generation != generation || state == _client_callback_states.end() ||
+            state->second.connected_sequence != sequence || state->second.disconnect_sequence != sequence ||
+            state->second.disconnect_callback_in_progress) {
+            return;
+        }
+        state->second.disconnect_callback_in_progress = true;
+    }
+    SAFE_CALLBACK_CALL(_callback_on_client_disconnected, address);
+
+    {
+        std::scoped_lock lock(_clients_mutex);
+        const auto state = _client_callback_states.find(key);
+        if (!_accepting_clients || _client_generation != generation || state == _client_callback_states.end() ||
+            state->second.disconnect_sequence != sequence) {
+            return;
+        }
+        state->second.connected_sequence = 0;
+        state->second.disconnect_sequence = 0;
+        state->second.disconnect_callback_in_progress = false;
+
+        _client_callback_states.erase(state);
+    }
+    _promote_pending_client_session(key, generation);
+}
+
+void PeripheralWindows::_promote_pending_client_session(const std::string& key, uint64_t generation) {
+    GattSession session{nullptr};
+    {
+        std::scoped_lock lock(_clients_mutex);
+        const auto pending = _pending_client_sessions.find(key);
+        if (!_accepting_clients || _client_generation != generation || _client_sessions.count(key) != 0 ||
+            pending == _pending_client_sessions.end() || pending->second.generation != generation) {
+            return;
+        }
+        session = pending->second.session;
+        _pending_client_sessions.erase(pending);
+    }
+
+    try {
+        _observe_session(session, generation);
+    } catch (const std::exception& ex) {
+        SIMPLEBLE_LOG_WARN(fmt::format("Failed to promote a Windows local peripheral client: {}", ex.what()));
+    } catch (...) {
+        SIMPLEBLE_LOG_WARN("Failed to promote a Windows local peripheral client");
+    }
+}
+
+std::pair<std::string, BluetoothAddress> PeripheralWindows::_session_identity(const GattSession& session) {
+    const std::string device_id = winrt::to_string(session.DeviceId().Id());
+    const BluetoothAddress address = _bluetooth_address_from_id(device_id);
+    if (!address.empty()) {
+        return {device_id, address};
+    }
+    return {device_id, device_id};
+}
+
+}  // namespace SimpleBLE::Local

--- a/simpleble/src/backends/windows/LocalPeripheralWindows.cpp
+++ b/simpleble/src/backends/windows/LocalPeripheralWindows.cpp
@@ -20,6 +20,31 @@ using namespace winrt::Windows::Devices::Bluetooth::GenericAttributeProfile;
 PeripheralWindows::PeripheralWindows(winrt::Windows::Devices::Bluetooth::BluetoothAdapter adapter)
     : _adapter(std::move(adapter)) {}
 
+void PeripheralWindows::ClientSession::close() noexcept {
+    if (!session) {
+        return;
+    }
+    try {
+        if (status_changed_token) {
+            session.SessionStatusChanged(status_changed_token);
+        }
+    } catch (const std::exception& ex) {
+        SIMPLEBLE_LOG_WARN(fmt::format("Failed to remove Windows client session handler: {}", ex.what()));
+    } catch (...) {
+        SIMPLEBLE_LOG_WARN("Failed to remove Windows client session handler");
+    }
+    status_changed_token = {};
+
+    try {
+        session.Close();
+    } catch (const std::exception& ex) {
+        SIMPLEBLE_LOG_WARN(fmt::format("Failed to close Windows client session: {}", ex.what()));
+    } catch (...) {
+        SIMPLEBLE_LOG_WARN("Failed to close Windows client session");
+    }
+    session = nullptr;
+}
+
 PeripheralWindows::~PeripheralWindows() {
     _callback_on_client_connected.unload();
     _callback_on_client_disconnected.unload();
@@ -72,10 +97,6 @@ void PeripheralWindows::remove_all_services() {
 
 void PeripheralWindows::start() {
     std::scoped_lock lock(_lifecycle_mutex);
-    if (_cleanup_required) {
-        throw Exception::OperationFailed(
-            "The previous Windows peripheral operation requires cleanup; call stop() before starting again.");
-    }
     if (_started.load()) {
         return;
     }
@@ -115,13 +136,12 @@ void PeripheralWindows::start() {
         }
     }
 
-    const auto services_snapshot = _services;
     auto run = std::make_shared<RunState>();
     auto weak_self = weak_from_this();
     std::weak_ptr<RunState> weak_run = run;
     const ServiceWindows::SessionObserver session_observer = [weak_self, weak_run](const GattSession& session) {
         const auto state = weak_run.lock();
-        if (!state || !state->active.load()) {
+        if (!state || !state->active->load()) {
             return;
         }
         if (auto self = weak_self.lock()) {
@@ -134,146 +154,76 @@ void PeripheralWindows::start() {
             }
         }
     };
-    const ServiceWindows::ActivityObserver activity_observer = [weak_run]() {
-        const auto state = weak_run.lock();
-        return state && state->active.load();
-    };
-
-    for (const auto& service : services_snapshot) {
-        service->freeze();
-    }
     _run = run;
 
-    bool rollback_failed = false;
     try {
-        for (const auto& service : services_snapshot) {
-            service->create_native(session_observer, activity_observer);
+        for (const auto& service : _services) {
+            service->freeze();
+            service->create_native(session_observer, run->active);
         }
 
-        try {
-            WinRT::MtaManager::get().execute_sync([&publication_order]() {
-                for (const auto& service : publication_order) {
-                    // WinRT publishes each primary GATT service through its own provider. Starting every provider
-                    // keeps the complete GATT table available. Windows owns the shared advertisement payload and may
-                    // omit UUIDs that do not fit, reporting StartedWithoutAllAdvertisementData for those providers.
-                    service->start_advertising();
-                }
-            });
-            // Wait on the calling thread so the process-wide MTA executor remains available to scanning, GATT I/O,
-            // notifications, and status events while Windows finishes publishing the providers.
+        WinRT::MtaManager::get().execute_sync([&publication_order]() {
             for (const auto& service : publication_order) {
-                service->wait_until_advertising();
+                // WinRT publishes each primary GATT service through its own provider. Starting every provider keeps
+                // the complete GATT table available. Windows owns the shared advertisement payload and may omit UUIDs
+                // that do not fit, reporting StartedWithoutAllAdvertisementData for those providers.
+                service->start_advertising();
             }
-        } catch (...) {
-            const auto start_error = std::current_exception();
-            run->active.store(false);
-            try {
-                WinRT::MtaManager::get().execute_sync([&publication_order, &rollback_failed]() {
-                    for (const auto& service : publication_order) {
-                        try {
-                            service->stop_advertising();
-                        } catch (...) {
-                            rollback_failed = true;
-                        }
-                    }
-                });
-            } catch (...) {
-                rollback_failed = true;
-            }
-            std::rethrow_exception(start_error);
+        });
+        // Wait on the calling thread so the process-wide MTA executor remains available to scanning, GATT I/O,
+        // notifications, and status events while Windows finishes publishing the providers.
+        for (const auto& service : publication_order) {
+            service->wait_until_advertising();
         }
         _started.store(true);
-    } catch (const std::exception& ex) {
-        run->active.store(false);
-        _clear_client_sessions(run);
-        if (!rollback_failed) {
-            for (const auto& service : services_snapshot) {
-                service->destroy_native();
-                service->unfreeze();
-            }
-            _run.reset();
-        }
-        _cleanup_required = rollback_failed;
-        if (rollback_failed) {
-            SIMPLEBLE_LOG_ERROR(
-                "Failed to roll back every Windows local service; the peripheral remains frozen until stop() "
-                "succeeds.");
-        }
-        SIMPLEBLE_LOG_ERROR(fmt::format("Failed to start Windows local peripheral: {}", ex.what()));
-        throw;
     } catch (...) {
-        run->active.store(false);
+        const auto start_error = std::current_exception();
+        run->active->store(false);
         _clear_client_sessions(run);
-        if (!rollback_failed) {
-            for (const auto& service : services_snapshot) {
-                service->destroy_native();
-                service->unfreeze();
-            }
-            _run.reset();
+        if (_stop_advertising()) {
+            SIMPLEBLE_LOG_WARN(
+                "Windows reported an error while rolling back advertising; the native providers were released.");
         }
-        _cleanup_required = rollback_failed;
-        if (rollback_failed) {
-            SIMPLEBLE_LOG_ERROR(
-                "Failed to roll back every Windows local service; the peripheral remains frozen until stop() "
-                "succeeds.");
+        for (const auto& service : _services) {
+            service->destroy_native();
+            service->unfreeze();
         }
+        _run.reset();
+        _started.store(false);
         SIMPLEBLE_LOG_ERROR("Failed to start Windows local peripheral");
-        throw;
+        std::rethrow_exception(start_error);
     }
 }
 
 void PeripheralWindows::stop() {
     std::scoped_lock lock(_lifecycle_mutex);
-    if (!_started.load() && !_cleanup_required) {
+    if (!_started.load()) {
         return;
     }
 
     const auto run = _run;
     if (run) {
-        run->active.store(false);
+        run->active->store(false);
         _clear_client_sessions(run);
     }
 
-    std::exception_ptr first_error;
-    try {
-        WinRT::MtaManager::get().execute_sync([this]() {
-            std::exception_ptr stop_error;
-            for (const auto& service : _services) {
-                try {
-                    service->stop_advertising();
-                } catch (...) {
-                    if (!stop_error) {
-                        stop_error = std::current_exception();
-                    }
-                }
-            }
-            if (stop_error) {
-                std::rethrow_exception(stop_error);
-            }
-        });
-    } catch (...) {
-        first_error = std::current_exception();
-    }
-
-    if (first_error) {
-        _cleanup_required = true;
-        std::rethrow_exception(first_error);
-    }
-
+    const auto stop_error = _stop_advertising();
     for (const auto& service : _services) {
         service->destroy_native();
         service->unfreeze();
     }
     _run.reset();
     _started.store(false);
-    _cleanup_required = false;
+    if (stop_error) {
+        std::rethrow_exception(stop_error);
+    }
 }
 
 bool PeripheralWindows::is_started() { return _started.load(); }
 
 bool PeripheralWindows::is_advertising() {
     std::scoped_lock lock(_lifecycle_mutex);
-    if (!_started.load() && !_cleanup_required) {
+    if (!_started.load()) {
         return false;
     }
     return WinRT::MtaManager::get().execute_sync<bool>([this]() {
@@ -300,22 +250,21 @@ void PeripheralWindows::set_callback_on_client_disconnected(
 }
 
 void PeripheralWindows::_ensure_mutable() const {
-    if (_started.load() || _cleanup_required) {
+    if (_started.load()) {
         throw Exception::OperationFailed("The local peripheral cannot be changed while it is started.");
     }
 }
 
 void PeripheralWindows::_observe_session(const std::shared_ptr<RunState>& run, const GattSession& session) {
-    if (!run || !run->active.load() || !session) {
+    if (!run || !run->active->load() || !session) {
         return;
     }
 
     const auto [key, address] = _session_identity(session);
-    GattSession previous_session{nullptr};
-    winrt::event_token previous_token{};
+    ClientSession previous;
     {
         std::scoped_lock lock(run->clients_mutex);
-        if (!run->active.load()) {
+        if (!run->active->load()) {
             return;
         }
         const auto existing = run->client_sessions.find(key);
@@ -326,24 +275,11 @@ void PeripheralWindows::_observe_session(const std::shared_ptr<RunState>& run, c
         if (existing == run->client_sessions.end()) {
             run->client_sessions.emplace(key, ClientSession{session, {}, address, false});
         } else {
-            previous_session = existing->second.session;
-            previous_token = existing->second.status_changed_token;
-            existing->second = ClientSession{session, {}, address, existing->second.connected};
+            previous = std::move(existing->second);
+            existing->second = ClientSession{session, {}, address, previous.connected};
         }
     }
-
-    if (previous_session) {
-        try {
-            if (previous_token) {
-                previous_session.SessionStatusChanged(previous_token);
-            }
-        } catch (...) {
-        }
-        try {
-            previous_session.Close();
-        } catch (...) {
-        }
-    }
+    previous.close();
 
     auto weak_self = weak_from_this();
     std::weak_ptr<RunState> weak_run = run;
@@ -352,7 +288,7 @@ void PeripheralWindows::_observe_session(const std::shared_ptr<RunState>& run, c
         token = session.SessionStatusChanged([weak_self, weak_run, key](const GattSession& sender,
                                                                         const GattSessionStatusChangedEventArgs& args) {
             const auto state = weak_run.lock();
-            if (!state || !state->active.load()) {
+            if (!state || !state->active->load()) {
                 return;
             }
             if (auto self = weak_self.lock()) {
@@ -373,10 +309,8 @@ void PeripheralWindows::_observe_session(const std::shared_ptr<RunState>& run, c
                 run->client_sessions.erase(it);
             }
         }
-        try {
-            session.Close();
-        } catch (...) {
-        }
+        ClientSession failed{session, {}, address, false};
+        failed.close();
         throw;
     }
 
@@ -391,54 +325,40 @@ void PeripheralWindows::_observe_session(const std::shared_ptr<RunState>& run, c
                 run->client_sessions.erase(it);
             }
         }
-        try {
-            session.SessionStatusChanged(token);
-        } catch (...) {
-        }
-        try {
-            session.Close();
-        } catch (...) {
-        }
+        ClientSession failed{session, token, address, false};
+        failed.close();
         throw;
     }
-    bool keep_token = false;
-    bool close_session = false;
+
+    ClientSession closed;
     bool notify_connected = false;
     bool notify_disconnected = false;
     {
         std::scoped_lock lock(run->clients_mutex);
         const auto it = run->client_sessions.find(key);
-        if (run->active.load() && it != run->client_sessions.end() &&
-            winrt::get_abi(it->second.session) == winrt::get_abi(session)) {
+        if (it == run->client_sessions.end() || winrt::get_abi(it->second.session) != winrt::get_abi(session)) {
+            closed = ClientSession{session, token, address, false};
+        } else if (!run->active->load()) {
             it->second.status_changed_token = token;
-            keep_token = true;
+            closed = std::move(it->second);
+            run->client_sessions.erase(it);
+        } else {
+            it->second.status_changed_token = token;
             if (status == GattSessionStatus::Active && !it->second.connected) {
                 it->second.connected = true;
                 notify_connected = true;
             } else if (status == GattSessionStatus::Closed) {
                 notify_disconnected = it->second.connected;
+                closed = std::move(it->second);
                 run->client_sessions.erase(it);
-                keep_token = false;
-                close_session = true;
             }
         }
     }
 
-    if (!keep_token) {
-        try {
-            session.SessionStatusChanged(token);
-        } catch (...) {
-        }
-    }
-    if (close_session) {
-        try {
-            session.Close();
-        } catch (...) {
-        }
-    }
-    if (notify_connected && run->active.load()) {
+    closed.close();
+    if (notify_connected && run->active->load()) {
         SAFE_CALLBACK_CALL(_callback_on_client_connected, address);
-    } else if (notify_disconnected && run->active.load()) {
+    } else if (notify_disconnected && run->active->load()) {
         SAFE_CALLBACK_CALL(_callback_on_client_disconnected, address);
     }
 }
@@ -447,14 +367,13 @@ void PeripheralWindows::_on_session_status_changed(const std::shared_ptr<RunStat
                                                    const GattSession& sender,
                                                    const GattSessionStatusChangedEventArgs& args) {
     BluetoothAddress address;
-    GattSession session{nullptr};
-    winrt::event_token token{};
+    ClientSession closed;
     bool notify_connected = false;
     bool notify_disconnected = false;
     {
         std::scoped_lock lock(run->clients_mutex);
         const auto it = run->client_sessions.find(key);
-        if (!run->active.load() || it == run->client_sessions.end() ||
+        if (!run->active->load() || it == run->client_sessions.end() ||
             winrt::get_abi(it->second.session) != winrt::get_abi(sender)) {
             return;
         }
@@ -464,60 +383,55 @@ void PeripheralWindows::_on_session_status_changed(const std::shared_ptr<RunStat
             it->second.connected = true;
             notify_connected = true;
         } else if (args.Status() == GattSessionStatus::Closed) {
-            session = it->second.session;
-            token = it->second.status_changed_token;
             notify_disconnected = it->second.connected;
+            closed = std::move(it->second);
             run->client_sessions.erase(it);
         }
     }
 
-    if (session) {
-        try {
-            if (token) {
-                session.SessionStatusChanged(token);
-            }
-        } catch (...) {
-        }
-        try {
-            session.Close();
-        } catch (...) {
-        }
-    }
-    if (notify_connected && run->active.load()) {
+    closed.close();
+    if (notify_connected && run->active->load()) {
         SAFE_CALLBACK_CALL(_callback_on_client_connected, address);
-    } else if (notify_disconnected && run->active.load()) {
+    } else if (notify_disconnected && run->active->load()) {
         SAFE_CALLBACK_CALL(_callback_on_client_disconnected, address);
     }
+}
+
+std::exception_ptr PeripheralWindows::_stop_advertising() noexcept {
+    std::exception_ptr first_error;
+    try {
+        WinRT::MtaManager::get().execute_sync([this, &first_error]() {
+            for (const auto& service : _services) {
+                try {
+                    service->stop_advertising();
+                } catch (...) {
+                    if (!first_error) {
+                        first_error = std::current_exception();
+                    }
+                }
+            }
+        });
+    } catch (...) {
+        if (!first_error) {
+            first_error = std::current_exception();
+        }
+    }
+    return first_error;
 }
 
 void PeripheralWindows::_clear_client_sessions(const std::shared_ptr<RunState>& run) noexcept {
     if (!run) {
         return;
     }
-    run->active.store(false);
+    run->active->store(false);
 
     std::map<std::string, ClientSession> sessions;
     {
         std::scoped_lock lock(run->clients_mutex);
         sessions.swap(run->client_sessions);
     }
-    for (auto& [key, client] : sessions) {
-        try {
-            if (client.status_changed_token) {
-                client.session.SessionStatusChanged(client.status_changed_token);
-            }
-        } catch (const std::exception& ex) {
-            SIMPLEBLE_LOG_WARN(fmt::format("Failed to remove Windows client session handler: {}", ex.what()));
-        } catch (...) {
-            SIMPLEBLE_LOG_WARN("Failed to remove Windows client session handler");
-        }
-        try {
-            client.session.Close();
-        } catch (const std::exception& ex) {
-            SIMPLEBLE_LOG_WARN(fmt::format("Failed to close Windows client session: {}", ex.what()));
-        } catch (...) {
-            SIMPLEBLE_LOG_WARN("Failed to close Windows client session");
-        }
+    for (auto& entry : sessions) {
+        entry.second.close();
     }
 }
 

--- a/simpleble/src/backends/windows/LocalPeripheralWindows.cpp
+++ b/simpleble/src/backends/windows/LocalPeripheralWindows.cpp
@@ -12,7 +12,6 @@
 #include "MtaManager.h"
 #include "Utils.h"
 #include "winrt/Windows.Foundation.Metadata.h"
-#include "winrt/Windows.System.Threading.h"
 
 namespace SimpleBLE::Local {
 
@@ -75,12 +74,6 @@ std::shared_ptr<ServiceBase> PeripheralWindows::add_service(BluetoothUUID uuid) 
                 return self->_active_client_generation();
             }
             return 0;
-        },
-        [weak_self](uint64_t generation) {
-            if (auto self = weak_self.lock()) {
-                return self->_client_callbacks_are_enabled(generation);
-            }
-            return false;
         });
     _services.push_back(service);
     return service;
@@ -98,7 +91,7 @@ void PeripheralWindows::remove_all_services() {
 }
 
 void PeripheralWindows::start() {
-    std::unique_lock lock(_lifecycle_mutex);
+    std::scoped_lock lock(_lifecycle_mutex);
     if (_cleanup_required) {
         throw Exception::OperationFailed(
             "The previous Windows peripheral operation requires cleanup; call stop() before starting again.");
@@ -152,7 +145,6 @@ void PeripheralWindows::start() {
         std::scoped_lock clients_lock(_clients_mutex);
         generation = ++_client_generation;
         _accepting_clients = true;
-        _client_callbacks_enabled = false;
     }
     for (const auto& service : services_snapshot) {
         service->activate(generation);
@@ -193,13 +185,7 @@ void PeripheralWindows::start() {
             }
             std::rethrow_exception(start_error);
         }
-        {
-            std::scoped_lock clients_lock(_clients_mutex);
-            _started.store(true);
-        }
-        for (const auto& service : services_snapshot) {
-            service->reconcile_subscriptions(generation);
-        }
+        _started.store(true);
     } catch (const std::exception& ex) {
         _clear_client_sessions();
         for (const auto& service : services_snapshot) {
@@ -234,31 +220,6 @@ void PeripheralWindows::start() {
         }
         SIMPLEBLE_LOG_ERROR("Failed to start Windows local peripheral");
         throw;
-    }
-
-    lock.unlock();
-    auto weak_self = weak_from_this();
-    try {
-        winrt::Windows::System::Threading::ThreadPool::RunAsync(
-            [weak_self, generation, services_snapshot](const winrt::Windows::Foundation::IAsyncAction&) {
-                if (auto self = weak_self.lock()) {
-                    self->_enable_client_callbacks(generation);
-                    for (const auto& service : services_snapshot) {
-                        service->enable_subscription_callbacks(generation);
-                    }
-                }
-            });
-    } catch (...) {
-        const auto schedule_error = std::current_exception();
-        try {
-            stop();
-        } catch (const std::exception& ex) {
-            SIMPLEBLE_LOG_ERROR(fmt::format(
-                "Failed to roll back Windows local peripheral after callback scheduling failed: {}", ex.what()));
-        } catch (...) {
-            SIMPLEBLE_LOG_ERROR("Failed to roll back Windows local peripheral after callback scheduling failed");
-        }
-        std::rethrow_exception(schedule_error);
     }
 }
 
@@ -417,9 +378,7 @@ void PeripheralWindows::_observe_session(const GattSession& session, uint64_t ex
             const auto status = session.SessionStatus();
             if (status == GattSessionStatus::Active && !it->second.connected) {
                 it->second.connected = true;
-                if (_started.load() && _client_callbacks_enabled) {
-                    notify_connected = true;
-                }
+                notify_connected = true;
             } else if (status == GattSessionStatus::Closed) {
                 _client_sessions.erase(it);
                 keep_token = false;
@@ -433,7 +392,7 @@ void PeripheralWindows::_observe_session(const GattSession& session, uint64_t ex
         } catch (...) {
         }
     }
-    if (notify_connected && _client_callbacks_are_enabled(generation)) {
+    if (notify_connected && _active_client_generation() == generation) {
         SAFE_CALLBACK_CALL(_callback_on_client_connected, address);
     }
 }
@@ -457,14 +416,12 @@ void PeripheralWindows::_on_session_status_changed(const std::string& key, uint6
         address = it->second.address;
         if (args.Status() == GattSessionStatus::Active && !it->second.connected) {
             it->second.connected = true;
-            if (_started.load() && _client_callbacks_enabled) {
-                notify_connected = true;
-            }
+            notify_connected = true;
         } else if (args.Status() == GattSessionStatus::Closed) {
             session = it->second.session;
             token = it->second.status_changed_token;
             revoke_token = static_cast<bool>(token);
-            notify_disconnected = it->second.connected && _started.load() && _client_callbacks_enabled;
+            notify_disconnected = it->second.connected;
             _client_sessions.erase(it);
         }
     }
@@ -475,9 +432,9 @@ void PeripheralWindows::_on_session_status_changed(const std::string& key, uint6
         } catch (...) {
         }
     }
-    if (notify_connected && _client_callbacks_are_enabled(generation)) {
+    if (notify_connected && _active_client_generation() == generation) {
         SAFE_CALLBACK_CALL(_callback_on_client_connected, address);
-    } else if (notify_disconnected && _client_callbacks_are_enabled(generation)) {
+    } else if (notify_disconnected && _active_client_generation() == generation) {
         SAFE_CALLBACK_CALL(_callback_on_client_disconnected, address);
     }
 }
@@ -487,7 +444,6 @@ void PeripheralWindows::_clear_client_sessions() noexcept {
     {
         std::scoped_lock lock(_clients_mutex);
         _accepting_clients = false;
-        _client_callbacks_enabled = false;
         ++_client_generation;
         sessions.swap(_client_sessions);
     }
@@ -510,32 +466,6 @@ uint64_t PeripheralWindows::_active_client_generation() {
         return 0;
     }
     return _client_generation;
-}
-
-bool PeripheralWindows::_client_callbacks_are_enabled(uint64_t generation) {
-    std::scoped_lock lock(_clients_mutex);
-    return _started.load() && _accepting_clients && _client_callbacks_enabled && _client_generation == generation;
-}
-
-void PeripheralWindows::_enable_client_callbacks(uint64_t generation) {
-    std::vector<BluetoothAddress> connected_clients;
-    {
-        std::scoped_lock lock(_clients_mutex);
-        if (!_started.load() || !_accepting_clients || _client_generation != generation) {
-            return;
-        }
-        _client_callbacks_enabled = true;
-        for (const auto& [key, client] : _client_sessions) {
-            if (client.generation == generation && client.connected) {
-                connected_clients.push_back(client.address);
-            }
-        }
-    }
-    for (const auto& address : connected_clients) {
-        if (_client_callbacks_are_enabled(generation)) {
-            SAFE_CALLBACK_CALL(_callback_on_client_connected, address);
-        }
-    }
 }
 
 std::pair<std::string, BluetoothAddress> PeripheralWindows::_session_identity(const GattSession& session) {

--- a/simpleble/src/backends/windows/LocalPeripheralWindows.h
+++ b/simpleble/src/backends/windows/LocalPeripheralWindows.h
@@ -54,23 +54,8 @@ class PeripheralWindows : public PeripheralBase, public std::enable_shared_from_
         winrt::event_token status_changed_token;
         BluetoothAddress address;
         bool connected{false};
-        bool connect_callback_pending{false};
-        bool connect_callback_in_progress{false};
-        bool connected_notified{false};
-        bool closed{false};
         uint64_t generation;
         uint64_t sequence;
-    };
-
-    struct ClientCallbackState {
-        uint64_t connected_sequence{0};
-        uint64_t disconnect_sequence{0};
-        bool disconnect_callback_in_progress{false};
-    };
-
-    struct PendingClientSession {
-        GattSession session;
-        uint64_t generation;
     };
 
     winrt::Windows::Devices::Bluetooth::BluetoothAdapter _adapter{nullptr};
@@ -81,8 +66,6 @@ class PeripheralWindows : public PeripheralBase, public std::enable_shared_from_
     mutable std::mutex _lifecycle_mutex;
 
     std::map<std::string, ClientSession> _client_sessions;
-    std::map<std::string, ClientCallbackState> _client_callback_states;
-    std::map<std::string, PendingClientSession> _pending_client_sessions;
     std::mutex _clients_mutex;
     uint64_t _client_generation{0};
     uint64_t _next_client_sequence{0};
@@ -99,10 +82,6 @@ class PeripheralWindows : public PeripheralBase, public std::enable_shared_from_
     uint64_t _active_client_generation();
     bool _client_callbacks_are_enabled(uint64_t generation);
     void _enable_client_callbacks(uint64_t generation);
-    void _deliver_client_connected(const std::string& key, uint64_t generation, uint64_t sequence);
-    void _deliver_client_disconnected(const std::string& key, uint64_t generation, uint64_t sequence,
-                                      const BluetoothAddress& address);
-    void _promote_pending_client_session(const std::string& key, uint64_t generation);
     static std::pair<std::string, BluetoothAddress> _session_identity(const GattSession& session);
 };
 

--- a/simpleble/src/backends/windows/LocalPeripheralWindows.h
+++ b/simpleble/src/backends/windows/LocalPeripheralWindows.h
@@ -70,7 +70,6 @@ class PeripheralWindows : public PeripheralBase, public std::enable_shared_from_
     uint64_t _client_generation{0};
     uint64_t _next_client_sequence{0};
     bool _accepting_clients{false};
-    bool _client_callbacks_enabled{false};
     kvn::safe_callback<void(BluetoothAddress)> _callback_on_client_connected;
     kvn::safe_callback<void(BluetoothAddress)> _callback_on_client_disconnected;
 
@@ -80,8 +79,6 @@ class PeripheralWindows : public PeripheralBase, public std::enable_shared_from_
                                     const GattSession& sender, const GattSessionStatusChangedEventArgs& args);
     void _clear_client_sessions() noexcept;
     uint64_t _active_client_generation();
-    bool _client_callbacks_are_enabled(uint64_t generation);
-    void _enable_client_callbacks(uint64_t generation);
     static std::pair<std::string, BluetoothAddress> _session_identity(const GattSession& session);
 };
 

--- a/simpleble/src/backends/windows/LocalPeripheralWindows.h
+++ b/simpleble/src/backends/windows/LocalPeripheralWindows.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <atomic>
-#include <cstdint>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -54,31 +53,30 @@ class PeripheralWindows : public PeripheralBase, public std::enable_shared_from_
         winrt::event_token status_changed_token;
         BluetoothAddress address;
         bool connected{false};
-        uint64_t generation;
-        uint64_t sequence;
+    };
+
+    struct RunState {
+        std::atomic_bool active{true};
+        std::map<std::string, ClientSession> client_sessions;
+        std::mutex clients_mutex;
     };
 
     winrt::Windows::Devices::Bluetooth::BluetoothAdapter _adapter{nullptr};
     Advertisement _advertisement;
     std::vector<std::shared_ptr<ServiceWindows>> _services;
+    std::shared_ptr<RunState> _run;
     std::atomic_bool _started{false};
     bool _cleanup_required{false};
     mutable std::mutex _lifecycle_mutex;
 
-    std::map<std::string, ClientSession> _client_sessions;
-    std::mutex _clients_mutex;
-    uint64_t _client_generation{0};
-    uint64_t _next_client_sequence{0};
-    bool _accepting_clients{false};
     kvn::safe_callback<void(BluetoothAddress)> _callback_on_client_connected;
     kvn::safe_callback<void(BluetoothAddress)> _callback_on_client_disconnected;
 
     void _ensure_mutable() const;
-    void _observe_session(const GattSession& session, uint64_t expected_generation);
-    void _on_session_status_changed(const std::string& key, uint64_t generation, uint64_t sequence,
+    void _observe_session(const std::shared_ptr<RunState>& run, const GattSession& session);
+    void _on_session_status_changed(const std::shared_ptr<RunState>& run, const std::string& key,
                                     const GattSession& sender, const GattSessionStatusChangedEventArgs& args);
-    void _clear_client_sessions() noexcept;
-    uint64_t _active_client_generation();
+    void _clear_client_sessions(const std::shared_ptr<RunState>& run) noexcept;
     static std::pair<std::string, BluetoothAddress> _session_identity(const GattSession& session);
 };
 

--- a/simpleble/src/backends/windows/LocalPeripheralWindows.h
+++ b/simpleble/src/backends/windows/LocalPeripheralWindows.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <exception>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -49,14 +50,16 @@ class PeripheralWindows : public PeripheralBase, public std::enable_shared_from_
         winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattSessionStatusChangedEventArgs;
 
     struct ClientSession {
-        GattSession session;
-        winrt::event_token status_changed_token;
+        GattSession session{nullptr};
+        winrt::event_token status_changed_token{};
         BluetoothAddress address;
         bool connected{false};
+
+        void close() noexcept;
     };
 
     struct RunState {
-        std::atomic_bool active{true};
+        std::shared_ptr<std::atomic_bool> active{std::make_shared<std::atomic_bool>(true)};
         std::map<std::string, ClientSession> client_sessions;
         std::mutex clients_mutex;
     };
@@ -66,7 +69,6 @@ class PeripheralWindows : public PeripheralBase, public std::enable_shared_from_
     std::vector<std::shared_ptr<ServiceWindows>> _services;
     std::shared_ptr<RunState> _run;
     std::atomic_bool _started{false};
-    bool _cleanup_required{false};
     mutable std::mutex _lifecycle_mutex;
 
     kvn::safe_callback<void(BluetoothAddress)> _callback_on_client_connected;
@@ -76,6 +78,7 @@ class PeripheralWindows : public PeripheralBase, public std::enable_shared_from_
     void _observe_session(const std::shared_ptr<RunState>& run, const GattSession& session);
     void _on_session_status_changed(const std::shared_ptr<RunState>& run, const std::string& key,
                                     const GattSession& sender, const GattSessionStatusChangedEventArgs& args);
+    std::exception_ptr _stop_advertising() noexcept;
     void _clear_client_sessions(const std::shared_ptr<RunState>& run) noexcept;
     static std::pair<std::string, BluetoothAddress> _session_identity(const GattSession& session);
 };

--- a/simpleble/src/backends/windows/LocalPeripheralWindows.h
+++ b/simpleble/src/backends/windows/LocalPeripheralWindows.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <kvn_safe_callback.hpp>
+
+#include "../common/LocalPeripheralBase.h"
+#include "winrt/Windows.Devices.Bluetooth.GenericAttributeProfile.h"
+#include "winrt/Windows.Devices.Bluetooth.h"
+
+namespace SimpleBLE::Local {
+
+class ServiceWindows;
+
+class PeripheralWindows : public PeripheralBase, public std::enable_shared_from_this<PeripheralWindows> {
+  public:
+    explicit PeripheralWindows(winrt::Windows::Devices::Bluetooth::BluetoothAdapter adapter);
+    ~PeripheralWindows() override;
+
+    void* underlying() const override;
+
+    Advertisement advertisement() override;
+    void set_advertisement(Advertisement advertisement) override;
+
+    std::shared_ptr<ServiceBase> add_service(BluetoothUUID uuid) override;
+    std::vector<std::shared_ptr<ServiceBase>> services() override;
+    void remove_all_services() override;
+
+    void start() override;
+    void stop() override;
+
+    bool is_started() override;
+    bool is_advertising() override;
+
+    void set_callback_on_client_connected(
+        std::function<void(BluetoothAddress client_address)> on_client_connected) override;
+    void set_callback_on_client_disconnected(
+        std::function<void(BluetoothAddress client_address)> on_client_disconnected) override;
+
+  private:
+    using GattSession = winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattSession;
+    using GattSessionStatusChangedEventArgs =
+        winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattSessionStatusChangedEventArgs;
+
+    struct ClientSession {
+        GattSession session;
+        winrt::event_token status_changed_token;
+        BluetoothAddress address;
+        bool connected{false};
+        bool connect_callback_pending{false};
+        bool connect_callback_in_progress{false};
+        bool connected_notified{false};
+        bool closed{false};
+        uint64_t generation;
+        uint64_t sequence;
+    };
+
+    struct ClientCallbackState {
+        uint64_t connected_sequence{0};
+        uint64_t disconnect_sequence{0};
+        bool disconnect_callback_in_progress{false};
+    };
+
+    struct PendingClientSession {
+        GattSession session;
+        uint64_t generation;
+    };
+
+    winrt::Windows::Devices::Bluetooth::BluetoothAdapter _adapter{nullptr};
+    Advertisement _advertisement;
+    std::vector<std::shared_ptr<ServiceWindows>> _services;
+    std::atomic_bool _started{false};
+    bool _cleanup_required{false};
+    mutable std::mutex _lifecycle_mutex;
+
+    std::map<std::string, ClientSession> _client_sessions;
+    std::map<std::string, ClientCallbackState> _client_callback_states;
+    std::map<std::string, PendingClientSession> _pending_client_sessions;
+    std::mutex _clients_mutex;
+    uint64_t _client_generation{0};
+    uint64_t _next_client_sequence{0};
+    bool _accepting_clients{false};
+    bool _client_callbacks_enabled{false};
+    kvn::safe_callback<void(BluetoothAddress)> _callback_on_client_connected;
+    kvn::safe_callback<void(BluetoothAddress)> _callback_on_client_disconnected;
+
+    void _ensure_mutable() const;
+    void _observe_session(const GattSession& session, uint64_t expected_generation);
+    void _on_session_status_changed(const std::string& key, uint64_t generation, uint64_t sequence,
+                                    const GattSession& sender, const GattSessionStatusChangedEventArgs& args);
+    void _clear_client_sessions() noexcept;
+    uint64_t _active_client_generation();
+    bool _client_callbacks_are_enabled(uint64_t generation);
+    void _enable_client_callbacks(uint64_t generation);
+    void _deliver_client_connected(const std::string& key, uint64_t generation, uint64_t sequence);
+    void _deliver_client_disconnected(const std::string& key, uint64_t generation, uint64_t sequence,
+                                      const BluetoothAddress& address);
+    void _promote_pending_client_session(const std::string& key, uint64_t generation);
+    static std::pair<std::string, BluetoothAddress> _session_identity(const GattSession& session);
+};
+
+}  // namespace SimpleBLE::Local

--- a/simpleble/src/backends/windows/LocalServiceWindows.cpp
+++ b/simpleble/src/backends/windows/LocalServiceWindows.cpp
@@ -54,7 +54,7 @@ void ServiceWindows::unfreeze() {
     _frozen = false;
 }
 
-void ServiceWindows::create_native(SessionObserver session_observer, ActivityObserver activity_observer) {
+void ServiceWindows::create_native(SessionObserver session_observer, std::shared_ptr<std::atomic_bool> active) {
     std::vector<std::shared_ptr<CharacteristicWindows>> characteristics;
     {
         std::scoped_lock lock(_mutex);
@@ -74,15 +74,14 @@ void ServiceWindows::create_native(SessionObserver session_observer, ActivityObs
     auto native = std::make_shared<NativeState>();
     native->provider = result.ServiceProvider();
     native->advertisement_status = native->provider.AdvertisementStatus();
-    native->activity_observer = activity_observer;
 
     try {
         for (const auto& characteristic : characteristics) {
-            characteristic->start_native(native->provider.Service(), session_observer, activity_observer);
+            characteristic->create_native(native->provider.Service(), session_observer, active);
         }
     } catch (...) {
         for (const auto& characteristic : characteristics) {
-            characteristic->stop_native();
+            characteristic->destroy_native();
         }
         throw;
     }
@@ -97,15 +96,15 @@ void ServiceWindows::destroy_native() noexcept {
         std::scoped_lock lock(_mutex);
         native.swap(_native);
         for (const auto& characteristic : _characteristics) {
-            characteristic->stop_native();
+            characteristic->destroy_native();
         }
     }
     _remove_advertisement_handler(native);
 }
 
 void ServiceWindows::start_advertising() {
-    const auto native = _native_snapshot();
-    if (!native || !native->active()) {
+    const auto native = _native_state();
+    if (!native) {
         throw Exception::OperationFailed(fmt::format("Local service {} is not active.", _uuid));
     }
 
@@ -126,9 +125,6 @@ void ServiceWindows::start_advertising() {
             [weak_native](const GattServiceProvider&,
                           const GattServiceProviderAdvertisementStatusChangedEventArgs& args) {
                 if (auto state = weak_native.lock()) {
-                    if (!state->active()) {
-                        return;
-                    }
                     {
                         std::scoped_lock lock(state->advertisement_mutex);
                         state->advertisement_status = args.Status();
@@ -149,7 +145,7 @@ void ServiceWindows::start_advertising() {
 }
 
 void ServiceWindows::wait_until_advertising() {
-    const auto native = _native_snapshot();
+    const auto native = _native_state();
     if (!native) {
         throw Exception::OperationFailed(fmt::format("Local service {} is not active.", _uuid));
     }
@@ -161,9 +157,6 @@ void ServiceWindows::wait_until_advertising() {
         return native->advertisement_status == AdvertisementStatus::Started ||
                native->advertisement_status == AdvertisementStatus::StartedWithoutAllAdvertisementData;
     });
-    if (!native->active()) {
-        throw Exception::OperationFailed(fmt::format("Advertising local service {} was cancelled.", _uuid));
-    }
     if (native->advertisement_status == AdvertisementStatus::Aborted) {
         const auto error = native->advertisement_error;
         throw Exception::OperationFailed(fmt::format("Windows aborted advertising local service {} (WinRT error {}).",
@@ -180,7 +173,7 @@ void ServiceWindows::wait_until_advertising() {
 }
 
 void ServiceWindows::stop_advertising() {
-    const auto native = _native_snapshot();
+    const auto native = _native_state();
     if (!native) {
         return;
     }
@@ -202,7 +195,7 @@ void ServiceWindows::stop_advertising() {
 }
 
 bool ServiceWindows::is_advertising() const {
-    const auto native = _native_snapshot();
+    const auto native = _native_state();
     if (!native) {
         return false;
     }
@@ -211,7 +204,7 @@ bool ServiceWindows::is_advertising() const {
            native->advertisement_status == AdvertisementStatus::StartedWithoutAllAdvertisementData;
 }
 
-std::shared_ptr<ServiceWindows::NativeState> ServiceWindows::_native_snapshot() const {
+std::shared_ptr<ServiceWindows::NativeState> ServiceWindows::_native_state() const {
     std::scoped_lock lock(_mutex);
     return _native;
 }

--- a/simpleble/src/backends/windows/LocalServiceWindows.cpp
+++ b/simpleble/src/backends/windows/LocalServiceWindows.cpp
@@ -32,28 +32,44 @@ ServiceWindows::ServiceWindows(BluetoothUUID uuid, SessionObserver session_obser
     _advertisement_status = _provider.AdvertisementStatus();
 }
 
-void ServiceWindows::initialize_handlers() {
+void ServiceWindows::_install_advertisement_handler(uint64_t generation) {
+    _remove_advertisement_handler();
     auto weak_self = weak_from_this();
     _advertisement_status_changed_token = _provider.AdvertisementStatusChanged(
-        [weak_self](const GattServiceProvider&, const GattServiceProviderAdvertisementStatusChangedEventArgs& args) {
+        [weak_self, generation](const GattServiceProvider&,
+                                const GattServiceProviderAdvertisementStatusChangedEventArgs& args) {
             if (auto self = weak_self.lock()) {
                 {
                     std::scoped_lock lock(self->_advertisement_mutex);
+                    if (self->_advertising_generation != generation) {
+                        return;
+                    }
                     self->_advertisement_status = args.Status();
                     self->_advertisement_error = args.Error();
+                    self->_advertisement_status_generation = generation;
                 }
                 self->_advertisement_cv.notify_all();
             }
         });
 }
 
+void ServiceWindows::_remove_advertisement_handler() noexcept {
+    if (!_advertisement_status_changed_token) {
+        return;
+    }
+    try {
+        _provider.AdvertisementStatusChanged(_advertisement_status_changed_token);
+    } catch (...) {
+        // The delegate captures weak ownership, so a failed revocation cannot access destroyed state.
+    }
+    _advertisement_status_changed_token = {};
+}
+
 ServiceWindows::~ServiceWindows() {
     try {
         if (_provider) {
             stop_advertising();
-            if (_advertisement_status_changed_token) {
-                _provider.AdvertisementStatusChanged(_advertisement_status_changed_token);
-            }
+            _remove_advertisement_handler();
         }
     } catch (...) {
     }
@@ -115,7 +131,7 @@ void ServiceWindows::unfreeze() {
     _frozen = false;
 }
 
-void ServiceWindows::start_advertising() {
+void ServiceWindows::start_advertising(uint64_t generation) {
     auto parameters = GattServiceProviderAdvertisingParameters();
     parameters.IsConnectable(true);
     parameters.IsDiscoverable(true);
@@ -123,13 +139,24 @@ void ServiceWindows::start_advertising() {
         std::scoped_lock lock(_advertisement_mutex);
         _advertisement_status = GattServiceProviderAdvertisementStatus::Created;
         _advertisement_error = BluetoothError::Success;
+        _advertising_generation = generation;
+        _advertisement_status_generation = generation;
         _advertising_requested = true;
     }
     try {
+        // Install a per-start delegate so a queued event from an older advertising cycle cannot satisfy this start.
+        _install_advertisement_handler(generation);
         _provider.StartAdvertising(parameters);
     } catch (...) {
-        std::scoped_lock lock(_advertisement_mutex);
-        _advertising_requested = false;
+        {
+            std::scoped_lock lock(_advertisement_mutex);
+            if (_advertising_generation == generation) {
+                _advertising_generation = 0;
+                _advertisement_status_generation = 0;
+                _advertising_requested = false;
+            }
+        }
+        _remove_advertisement_handler();
         throw;
     }
 }
@@ -138,14 +165,19 @@ void ServiceWindows::activate(uint64_t generation) { _active_generation.store(ge
 
 void ServiceWindows::deactivate() noexcept { _active_generation.store(0); }
 
-void ServiceWindows::wait_until_advertising() {
+void ServiceWindows::wait_until_advertising(uint64_t generation) {
     std::unique_lock lock(_advertisement_mutex);
     // WinRT can report a transient Aborted state before recovering to Started. Keep waiting for success and only
     // interpret the last observed state as a failure after the timeout.
-    _advertisement_cv.wait_for(lock, std::chrono::seconds(5), [this]() {
-        return _advertisement_status == GattServiceProviderAdvertisementStatus::Started ||
-               _advertisement_status == GattServiceProviderAdvertisementStatus::StartedWithoutAllAdvertisementData;
+    _advertisement_cv.wait_for(lock, std::chrono::seconds(5), [this, generation]() {
+        return _advertisement_status_generation == generation &&
+               (_advertisement_status == GattServiceProviderAdvertisementStatus::Started ||
+                _advertisement_status == GattServiceProviderAdvertisementStatus::StartedWithoutAllAdvertisementData);
     });
+    if (_advertising_generation != generation || _advertisement_status_generation != generation) {
+        throw Exception::OperationFailed(
+            fmt::format("Advertising local service {} was superseded by another lifecycle operation.", _uuid));
+    }
     if (_advertisement_status == GattServiceProviderAdvertisementStatus::Aborted) {
         const auto error = _advertisement_error;
         throw Exception::OperationFailed(fmt::format("Windows aborted advertising local service {} (WinRT error {}).",
@@ -172,10 +204,15 @@ void ServiceWindows::stop_advertising() {
     _provider.StopAdvertising();
     // StopAdvertising is a synchronous void operation. Some Windows stacks do not emit a follow-up Stopped status
     // event, so a successful return is the completion boundary for the local lifecycle.
-    std::scoped_lock lock(_advertisement_mutex);
-    _advertisement_status = GattServiceProviderAdvertisementStatus::Stopped;
-    _advertisement_error = BluetoothError::Success;
-    _advertising_requested = false;
+    {
+        std::scoped_lock lock(_advertisement_mutex);
+        _advertisement_status = GattServiceProviderAdvertisementStatus::Stopped;
+        _advertisement_error = BluetoothError::Success;
+        _advertisement_status_generation = _advertising_generation;
+        _advertising_generation = 0;
+        _advertising_requested = false;
+    }
+    _remove_advertisement_handler();
 }
 
 void ServiceWindows::reset_subscriptions() {
@@ -199,11 +236,10 @@ void ServiceWindows::reconcile_subscriptions(uint64_t generation) noexcept {
             characteristic->reconcile_subscriptions(generation);
         }
     } catch (const std::exception& ex) {
-        SIMPLEBLE_LOG_WARN(fmt::format("Failed to reconcile subscriptions for Windows local service {}: {}", _uuid,
-                                       ex.what()));
-    } catch (...) {
         SIMPLEBLE_LOG_WARN(
-            fmt::format("Failed to reconcile subscriptions for Windows local service {}", _uuid));
+            fmt::format("Failed to reconcile subscriptions for Windows local service {}: {}", _uuid, ex.what()));
+    } catch (...) {
+        SIMPLEBLE_LOG_WARN(fmt::format("Failed to reconcile subscriptions for Windows local service {}", _uuid));
     }
 }
 

--- a/simpleble/src/backends/windows/LocalServiceWindows.cpp
+++ b/simpleble/src/backends/windows/LocalServiceWindows.cpp
@@ -7,7 +7,6 @@
 #include <simpleble/Exceptions.h>
 
 #include "LocalCharacteristicWindows.h"
-#include "LoggingInternal.h"
 #include "MtaManager.h"
 #include "Utils.h"
 
@@ -16,63 +15,14 @@ namespace SimpleBLE::Local {
 using namespace winrt::Windows::Devices::Bluetooth;
 using namespace winrt::Windows::Devices::Bluetooth::GenericAttributeProfile;
 
-ServiceWindows::ServiceWindows(BluetoothUUID uuid, SessionObserver session_observer, ActivityObserver activity_observer)
-    : _uuid(std::move(uuid)),
-      _session_observer(std::move(session_observer)),
-      _activity_observer(std::move(activity_observer)) {
-    auto result = WinRT::MtaManager::get().execute_sync<GattServiceProviderResult>(
-        [this]() { return async_get(GattServiceProvider::CreateAsync(uuid_to_guid(_uuid))); });
-    if (result.Error() != BluetoothError::Success || !result.ServiceProvider()) {
-        throw Exception::OperationFailed(fmt::format("Failed to create local service {} (WinRT error {}).", _uuid,
-                                                     static_cast<int32_t>(result.Error())));
-    }
-    _provider = result.ServiceProvider();
-    _advertisement_status = _provider.AdvertisementStatus();
-}
-
-void ServiceWindows::_install_advertisement_handler(uint64_t generation) {
-    _remove_advertisement_handler();
-    auto weak_self = weak_from_this();
-    _advertisement_status_changed_token = _provider.AdvertisementStatusChanged(
-        [weak_self, generation](const GattServiceProvider&,
-                                const GattServiceProviderAdvertisementStatusChangedEventArgs& args) {
-            if (auto self = weak_self.lock()) {
-                {
-                    std::scoped_lock lock(self->_advertisement_mutex);
-                    if (self->_advertising_generation != generation) {
-                        return;
-                    }
-                    self->_advertisement_status = args.Status();
-                    self->_advertisement_error = args.Error();
-                    self->_advertisement_status_generation = generation;
-                }
-                self->_advertisement_cv.notify_all();
-            }
-        });
-}
-
-void ServiceWindows::_remove_advertisement_handler() noexcept {
-    if (!_advertisement_status_changed_token) {
-        return;
-    }
-    try {
-        _provider.AdvertisementStatusChanged(_advertisement_status_changed_token);
-    } catch (...) {
-        // The delegate captures weak ownership, so a failed revocation cannot access destroyed state.
-    }
-    _advertisement_status_changed_token = {};
-}
+ServiceWindows::ServiceWindows(BluetoothUUID uuid) : _uuid(std::move(uuid)) {}
 
 ServiceWindows::~ServiceWindows() {
     try {
-        if (_provider) {
-            stop_advertising();
-            _remove_advertisement_handler();
-        }
+        stop_advertising();
     } catch (...) {
     }
-    std::scoped_lock lock(_mutex);
-    _characteristics.clear();
+    destroy_native();
 }
 
 BluetoothUUID ServiceWindows::uuid() { return _uuid; }
@@ -84,25 +34,7 @@ std::shared_ptr<CharacteristicBase> ServiceWindows::add_characteristic(
         throw Exception::OperationFailed("The local service cannot be changed while its peripheral is started.");
     }
 
-    auto weak_self = weak_from_this();
-    auto characteristic = std::make_shared<CharacteristicWindows>(
-        _provider.Service(), std::move(uuid), std::move(capabilities),
-        [weak_self](const GattSession& session, uint64_t expected_generation) {
-            if (auto self = weak_self.lock()) {
-                const uint64_t generation = self->_current_generation();
-                if (generation != 0 && (expected_generation == 0 || expected_generation == generation) &&
-                    self->_session_observer) {
-                    self->_session_observer(session, generation);
-                }
-            }
-        },
-        [weak_self]() -> uint64_t {
-            if (auto self = weak_self.lock()) {
-                return self->_current_generation();
-            }
-            return 0;
-        });
-    characteristic->initialize_handlers();
+    auto characteristic = std::make_shared<CharacteristicWindows>(std::move(uuid), std::move(capabilities));
     _characteristics.push_back(characteristic);
     return characteristic;
 }
@@ -122,62 +54,125 @@ void ServiceWindows::unfreeze() {
     _frozen = false;
 }
 
-void ServiceWindows::start_advertising(uint64_t generation) {
+void ServiceWindows::create_native(SessionObserver session_observer, ActivityObserver activity_observer) {
+    std::vector<std::shared_ptr<CharacteristicWindows>> characteristics;
+    {
+        std::scoped_lock lock(_mutex);
+        if (_native) {
+            throw Exception::OperationFailed(fmt::format("Local service {} is already active.", _uuid));
+        }
+        characteristics = _characteristics;
+    }
+
+    auto result = WinRT::MtaManager::get().execute_sync<GattServiceProviderResult>(
+        [this]() { return async_get(GattServiceProvider::CreateAsync(uuid_to_guid(_uuid))); });
+    if (result.Error() != BluetoothError::Success || !result.ServiceProvider()) {
+        throw Exception::OperationFailed(fmt::format("Failed to create local service {} (WinRT error {}).", _uuid,
+                                                     static_cast<int32_t>(result.Error())));
+    }
+
+    auto native = std::make_shared<NativeState>();
+    native->provider = result.ServiceProvider();
+    native->advertisement_status = native->provider.AdvertisementStatus();
+    native->activity_observer = activity_observer;
+
+    try {
+        for (const auto& characteristic : characteristics) {
+            characteristic->start_native(native->provider.Service(), session_observer, activity_observer);
+        }
+    } catch (...) {
+        for (const auto& characteristic : characteristics) {
+            characteristic->stop_native();
+        }
+        throw;
+    }
+
+    std::scoped_lock lock(_mutex);
+    _native = std::move(native);
+}
+
+void ServiceWindows::destroy_native() noexcept {
+    std::shared_ptr<NativeState> native;
+    {
+        std::scoped_lock lock(_mutex);
+        native.swap(_native);
+        for (const auto& characteristic : _characteristics) {
+            characteristic->stop_native();
+        }
+    }
+    _remove_advertisement_handler(native);
+}
+
+void ServiceWindows::start_advertising() {
+    const auto native = _native_snapshot();
+    if (!native || !native->active()) {
+        throw Exception::OperationFailed(fmt::format("Local service {} is not active.", _uuid));
+    }
+
     auto parameters = GattServiceProviderAdvertisingParameters();
     parameters.IsConnectable(true);
     parameters.IsDiscoverable(true);
     {
-        std::scoped_lock lock(_advertisement_mutex);
-        _advertisement_status = GattServiceProviderAdvertisementStatus::Created;
-        _advertisement_error = BluetoothError::Success;
-        _advertising_generation = generation;
-        _advertisement_status_generation = generation;
-        _advertising_requested = true;
+        std::scoped_lock lock(native->advertisement_mutex);
+        native->advertisement_status = AdvertisementStatus::Created;
+        native->advertisement_error = BluetoothError::Success;
+        native->advertising_requested = true;
     }
+
+    std::weak_ptr<NativeState> weak_native = native;
     try {
-        // Install a per-start delegate so a queued event from an older advertising cycle cannot satisfy this start.
-        _install_advertisement_handler(generation);
-        _provider.StartAdvertising(parameters);
+        _remove_advertisement_handler(native);
+        native->advertisement_status_changed_token = native->provider.AdvertisementStatusChanged(
+            [weak_native](const GattServiceProvider&,
+                          const GattServiceProviderAdvertisementStatusChangedEventArgs& args) {
+                if (auto state = weak_native.lock()) {
+                    if (!state->active()) {
+                        return;
+                    }
+                    {
+                        std::scoped_lock lock(state->advertisement_mutex);
+                        state->advertisement_status = args.Status();
+                        state->advertisement_error = args.Error();
+                    }
+                    state->advertisement_cv.notify_all();
+                }
+            });
+        native->provider.StartAdvertising(parameters);
     } catch (...) {
         {
-            std::scoped_lock lock(_advertisement_mutex);
-            if (_advertising_generation == generation) {
-                _advertising_generation = 0;
-                _advertisement_status_generation = 0;
-                _advertising_requested = false;
-            }
+            std::scoped_lock lock(native->advertisement_mutex);
+            native->advertising_requested = false;
         }
-        _remove_advertisement_handler();
+        _remove_advertisement_handler(native);
         throw;
     }
 }
 
-void ServiceWindows::activate(uint64_t generation) { _active_generation.store(generation); }
+void ServiceWindows::wait_until_advertising() {
+    const auto native = _native_snapshot();
+    if (!native) {
+        throw Exception::OperationFailed(fmt::format("Local service {} is not active.", _uuid));
+    }
 
-void ServiceWindows::deactivate() noexcept { _active_generation.store(0); }
-
-void ServiceWindows::wait_until_advertising(uint64_t generation) {
-    std::unique_lock lock(_advertisement_mutex);
+    std::unique_lock lock(native->advertisement_mutex);
     // WinRT can report a transient Aborted state before recovering to Started. Keep waiting for success and only
     // interpret the last observed state as a failure after the timeout.
-    _advertisement_cv.wait_for(lock, std::chrono::seconds(5), [this, generation]() {
-        return _advertisement_status_generation == generation &&
-               (_advertisement_status == GattServiceProviderAdvertisementStatus::Started ||
-                _advertisement_status == GattServiceProviderAdvertisementStatus::StartedWithoutAllAdvertisementData);
+    native->advertisement_cv.wait_for(lock, std::chrono::seconds(5), [&native]() {
+        return native->advertisement_status == AdvertisementStatus::Started ||
+               native->advertisement_status == AdvertisementStatus::StartedWithoutAllAdvertisementData;
     });
-    if (_advertising_generation != generation || _advertisement_status_generation != generation) {
-        throw Exception::OperationFailed(
-            fmt::format("Advertising local service {} was superseded by another lifecycle operation.", _uuid));
+    if (!native->active()) {
+        throw Exception::OperationFailed(fmt::format("Advertising local service {} was cancelled.", _uuid));
     }
-    if (_advertisement_status == GattServiceProviderAdvertisementStatus::Aborted) {
-        const auto error = _advertisement_error;
+    if (native->advertisement_status == AdvertisementStatus::Aborted) {
+        const auto error = native->advertisement_error;
         throw Exception::OperationFailed(fmt::format("Windows aborted advertising local service {} (WinRT error {}).",
                                                      _uuid, static_cast<int32_t>(error)));
     }
-    if (_advertisement_status != GattServiceProviderAdvertisementStatus::Started &&
-        _advertisement_status != GattServiceProviderAdvertisementStatus::StartedWithoutAllAdvertisementData) {
-        const auto status = _advertisement_status;
-        const auto error = _advertisement_error;
+    if (native->advertisement_status != AdvertisementStatus::Started &&
+        native->advertisement_status != AdvertisementStatus::StartedWithoutAllAdvertisementData) {
+        const auto status = native->advertisement_status;
+        const auto error = native->advertisement_error;
         throw Exception::OperationFailed(
             fmt::format("Timed out while starting advertisement for local service {} (status {}, WinRT error {}).",
                         _uuid, static_cast<int32_t>(status), static_cast<int32_t>(error)));
@@ -185,50 +180,51 @@ void ServiceWindows::wait_until_advertising(uint64_t generation) {
 }
 
 void ServiceWindows::stop_advertising() {
+    const auto native = _native_snapshot();
+    if (!native) {
+        return;
+    }
     {
-        std::scoped_lock lock(_advertisement_mutex);
-        if (!_advertising_requested) {
+        std::scoped_lock lock(native->advertisement_mutex);
+        if (!native->advertising_requested) {
             return;
         }
     }
 
-    _provider.StopAdvertising();
-    // StopAdvertising is a synchronous void operation. Some Windows stacks do not emit a follow-up Stopped status
-    // event, so a successful return is the completion boundary for the local lifecycle.
+    native->provider.StopAdvertising();
     {
-        std::scoped_lock lock(_advertisement_mutex);
-        _advertisement_status = GattServiceProviderAdvertisementStatus::Stopped;
-        _advertisement_error = BluetoothError::Success;
-        _advertisement_status_generation = _advertising_generation;
-        _advertising_generation = 0;
-        _advertising_requested = false;
+        std::scoped_lock lock(native->advertisement_mutex);
+        native->advertisement_status = AdvertisementStatus::Stopped;
+        native->advertisement_error = BluetoothError::Success;
+        native->advertising_requested = false;
     }
-    _remove_advertisement_handler();
-}
-
-void ServiceWindows::reset_subscriptions() {
-    std::vector<std::shared_ptr<CharacteristicWindows>> characteristics;
-    {
-        std::scoped_lock lock(_mutex);
-        characteristics = _characteristics;
-    }
-    for (const auto& characteristic : characteristics) {
-        characteristic->reset_subscriptions();
-    }
+    _remove_advertisement_handler(native);
 }
 
 bool ServiceWindows::is_advertising() const {
-    std::scoped_lock lock(_advertisement_mutex);
-    return _advertisement_status == GattServiceProviderAdvertisementStatus::Started ||
-           _advertisement_status == GattServiceProviderAdvertisementStatus::StartedWithoutAllAdvertisementData;
+    const auto native = _native_snapshot();
+    if (!native) {
+        return false;
+    }
+    std::scoped_lock lock(native->advertisement_mutex);
+    return native->advertisement_status == AdvertisementStatus::Started ||
+           native->advertisement_status == AdvertisementStatus::StartedWithoutAllAdvertisementData;
 }
 
-uint64_t ServiceWindows::_current_generation() {
-    const uint64_t generation = _active_generation.load();
-    if (generation == 0 || !_activity_observer || _activity_observer() != generation) {
-        return 0;
+std::shared_ptr<ServiceWindows::NativeState> ServiceWindows::_native_snapshot() const {
+    std::scoped_lock lock(_mutex);
+    return _native;
+}
+
+void ServiceWindows::_remove_advertisement_handler(const std::shared_ptr<NativeState>& native) noexcept {
+    if (!native || !native->provider || !native->advertisement_status_changed_token) {
+        return;
     }
-    return generation;
+    try {
+        native->provider.AdvertisementStatusChanged(native->advertisement_status_changed_token);
+    } catch (...) {
+    }
+    native->advertisement_status_changed_token = {};
 }
 
 }  // namespace SimpleBLE::Local

--- a/simpleble/src/backends/windows/LocalServiceWindows.cpp
+++ b/simpleble/src/backends/windows/LocalServiceWindows.cpp
@@ -16,12 +16,10 @@ namespace SimpleBLE::Local {
 using namespace winrt::Windows::Devices::Bluetooth;
 using namespace winrt::Windows::Devices::Bluetooth::GenericAttributeProfile;
 
-ServiceWindows::ServiceWindows(BluetoothUUID uuid, SessionObserver session_observer, ActivityObserver activity_observer,
-                               CallbackObserver callback_observer)
+ServiceWindows::ServiceWindows(BluetoothUUID uuid, SessionObserver session_observer, ActivityObserver activity_observer)
     : _uuid(std::move(uuid)),
       _session_observer(std::move(session_observer)),
-      _activity_observer(std::move(activity_observer)),
-      _callback_observer(std::move(callback_observer)) {
+      _activity_observer(std::move(activity_observer)) {
     auto result = WinRT::MtaManager::get().execute_sync<GattServiceProviderResult>(
         [this]() { return async_get(GattServiceProvider::CreateAsync(uuid_to_guid(_uuid))); });
     if (result.Error() != BluetoothError::Success || !result.ServiceProvider()) {
@@ -103,13 +101,6 @@ std::shared_ptr<CharacteristicBase> ServiceWindows::add_characteristic(
                 return self->_current_generation();
             }
             return 0;
-        },
-        [weak_self](uint64_t generation) {
-            if (auto self = weak_self.lock()) {
-                return self->_current_generation() == generation && self->_callback_observer &&
-                       self->_callback_observer(generation);
-            }
-            return false;
         });
     characteristic->initialize_handlers();
     _characteristics.push_back(characteristic);
@@ -223,37 +214,6 @@ void ServiceWindows::reset_subscriptions() {
     }
     for (const auto& characteristic : characteristics) {
         characteristic->reset_subscriptions();
-    }
-}
-
-void ServiceWindows::reconcile_subscriptions(uint64_t generation) noexcept {
-    if (_current_generation() != generation) {
-        return;
-    }
-    try {
-        std::scoped_lock lock(_mutex);
-        for (const auto& characteristic : _characteristics) {
-            characteristic->reconcile_subscriptions(generation);
-        }
-    } catch (const std::exception& ex) {
-        SIMPLEBLE_LOG_WARN(
-            fmt::format("Failed to reconcile subscriptions for Windows local service {}: {}", _uuid, ex.what()));
-    } catch (...) {
-        SIMPLEBLE_LOG_WARN(fmt::format("Failed to reconcile subscriptions for Windows local service {}", _uuid));
-    }
-}
-
-void ServiceWindows::enable_subscription_callbacks(uint64_t generation) {
-    if (_current_generation() != generation) {
-        return;
-    }
-    std::vector<std::shared_ptr<CharacteristicWindows>> characteristics;
-    {
-        std::scoped_lock lock(_mutex);
-        characteristics = _characteristics;
-    }
-    for (const auto& characteristic : characteristics) {
-        characteristic->enable_subscription_callbacks(generation);
     }
 }
 

--- a/simpleble/src/backends/windows/LocalServiceWindows.cpp
+++ b/simpleble/src/backends/windows/LocalServiceWindows.cpp
@@ -1,0 +1,238 @@
+#include "LocalServiceWindows.h"
+
+#include <chrono>
+#include <utility>
+
+#include <fmt/format.h>
+#include <simpleble/Exceptions.h>
+
+#include "LocalCharacteristicWindows.h"
+#include "LoggingInternal.h"
+#include "MtaManager.h"
+#include "Utils.h"
+
+namespace SimpleBLE::Local {
+
+using namespace winrt::Windows::Devices::Bluetooth;
+using namespace winrt::Windows::Devices::Bluetooth::GenericAttributeProfile;
+
+ServiceWindows::ServiceWindows(BluetoothUUID uuid, SessionObserver session_observer, ActivityObserver activity_observer,
+                               CallbackObserver callback_observer)
+    : _uuid(std::move(uuid)),
+      _session_observer(std::move(session_observer)),
+      _activity_observer(std::move(activity_observer)),
+      _callback_observer(std::move(callback_observer)) {
+    auto result = WinRT::MtaManager::get().execute_sync<GattServiceProviderResult>(
+        [this]() { return async_get(GattServiceProvider::CreateAsync(uuid_to_guid(_uuid))); });
+    if (result.Error() != BluetoothError::Success || !result.ServiceProvider()) {
+        throw Exception::OperationFailed(fmt::format("Failed to create local service {} (WinRT error {}).", _uuid,
+                                                     static_cast<int32_t>(result.Error())));
+    }
+    _provider = result.ServiceProvider();
+    _advertisement_status = _provider.AdvertisementStatus();
+}
+
+void ServiceWindows::initialize_handlers() {
+    auto weak_self = weak_from_this();
+    _advertisement_status_changed_token = _provider.AdvertisementStatusChanged(
+        [weak_self](const GattServiceProvider&, const GattServiceProviderAdvertisementStatusChangedEventArgs& args) {
+            if (auto self = weak_self.lock()) {
+                {
+                    std::scoped_lock lock(self->_advertisement_mutex);
+                    self->_advertisement_status = args.Status();
+                    self->_advertisement_error = args.Error();
+                }
+                self->_advertisement_cv.notify_all();
+            }
+        });
+}
+
+ServiceWindows::~ServiceWindows() {
+    try {
+        if (_provider) {
+            stop_advertising();
+            if (_advertisement_status_changed_token) {
+                _provider.AdvertisementStatusChanged(_advertisement_status_changed_token);
+            }
+        }
+    } catch (...) {
+    }
+    std::scoped_lock lock(_mutex);
+    _characteristics.clear();
+}
+
+BluetoothUUID ServiceWindows::uuid() { return _uuid; }
+
+std::shared_ptr<CharacteristicBase> ServiceWindows::add_characteristic(
+    BluetoothUUID uuid, std::set<CharacteristicCapability> capabilities) {
+    std::scoped_lock lock(_mutex);
+    if (_frozen) {
+        throw Exception::OperationFailed("The local service cannot be changed while its peripheral is started.");
+    }
+
+    auto weak_self = weak_from_this();
+    auto characteristic = std::make_shared<CharacteristicWindows>(
+        _provider.Service(), std::move(uuid), std::move(capabilities),
+        [weak_self](const GattSession& session, uint64_t expected_generation) {
+            if (auto self = weak_self.lock()) {
+                const uint64_t generation = self->_current_generation();
+                if (generation != 0 && (expected_generation == 0 || expected_generation == generation) &&
+                    self->_session_observer) {
+                    self->_session_observer(session, generation);
+                }
+            }
+        },
+        [weak_self]() -> uint64_t {
+            if (auto self = weak_self.lock()) {
+                return self->_current_generation();
+            }
+            return 0;
+        },
+        [weak_self](uint64_t generation) {
+            if (auto self = weak_self.lock()) {
+                return self->_current_generation() == generation && self->_callback_observer &&
+                       self->_callback_observer(generation);
+            }
+            return false;
+        });
+    characteristic->initialize_handlers();
+    _characteristics.push_back(characteristic);
+    return characteristic;
+}
+
+std::vector<std::shared_ptr<CharacteristicBase>> ServiceWindows::characteristics() {
+    std::scoped_lock lock(_mutex);
+    return {_characteristics.begin(), _characteristics.end()};
+}
+
+void ServiceWindows::freeze() {
+    std::scoped_lock lock(_mutex);
+    _frozen = true;
+}
+
+void ServiceWindows::unfreeze() {
+    std::scoped_lock lock(_mutex);
+    _frozen = false;
+}
+
+void ServiceWindows::start_advertising() {
+    auto parameters = GattServiceProviderAdvertisingParameters();
+    parameters.IsConnectable(true);
+    parameters.IsDiscoverable(true);
+    {
+        std::scoped_lock lock(_advertisement_mutex);
+        _advertisement_status = GattServiceProviderAdvertisementStatus::Created;
+        _advertisement_error = BluetoothError::Success;
+        _advertising_requested = true;
+    }
+    try {
+        _provider.StartAdvertising(parameters);
+    } catch (...) {
+        std::scoped_lock lock(_advertisement_mutex);
+        _advertising_requested = false;
+        throw;
+    }
+}
+
+void ServiceWindows::activate(uint64_t generation) { _active_generation.store(generation); }
+
+void ServiceWindows::deactivate() noexcept { _active_generation.store(0); }
+
+void ServiceWindows::wait_until_advertising() {
+    std::unique_lock lock(_advertisement_mutex);
+    // WinRT can report a transient Aborted state before recovering to Started. Keep waiting for success and only
+    // interpret the last observed state as a failure after the timeout.
+    _advertisement_cv.wait_for(lock, std::chrono::seconds(5), [this]() {
+        return _advertisement_status == GattServiceProviderAdvertisementStatus::Started ||
+               _advertisement_status == GattServiceProviderAdvertisementStatus::StartedWithoutAllAdvertisementData;
+    });
+    if (_advertisement_status == GattServiceProviderAdvertisementStatus::Aborted) {
+        const auto error = _advertisement_error;
+        throw Exception::OperationFailed(fmt::format("Windows aborted advertising local service {} (WinRT error {}).",
+                                                     _uuid, static_cast<int32_t>(error)));
+    }
+    if (_advertisement_status != GattServiceProviderAdvertisementStatus::Started &&
+        _advertisement_status != GattServiceProviderAdvertisementStatus::StartedWithoutAllAdvertisementData) {
+        const auto status = _advertisement_status;
+        const auto error = _advertisement_error;
+        throw Exception::OperationFailed(
+            fmt::format("Timed out while starting advertisement for local service {} (status {}, WinRT error {}).",
+                        _uuid, static_cast<int32_t>(status), static_cast<int32_t>(error)));
+    }
+}
+
+void ServiceWindows::stop_advertising() {
+    {
+        std::scoped_lock lock(_advertisement_mutex);
+        if (!_advertising_requested) {
+            return;
+        }
+    }
+
+    _provider.StopAdvertising();
+    // StopAdvertising is a synchronous void operation. Some Windows stacks do not emit a follow-up Stopped status
+    // event, so a successful return is the completion boundary for the local lifecycle.
+    std::scoped_lock lock(_advertisement_mutex);
+    _advertisement_status = GattServiceProviderAdvertisementStatus::Stopped;
+    _advertisement_error = BluetoothError::Success;
+    _advertising_requested = false;
+}
+
+void ServiceWindows::reset_subscriptions() {
+    std::vector<std::shared_ptr<CharacteristicWindows>> characteristics;
+    {
+        std::scoped_lock lock(_mutex);
+        characteristics = _characteristics;
+    }
+    for (const auto& characteristic : characteristics) {
+        characteristic->reset_subscriptions();
+    }
+}
+
+void ServiceWindows::reconcile_subscriptions(uint64_t generation) noexcept {
+    if (_current_generation() != generation) {
+        return;
+    }
+    try {
+        std::scoped_lock lock(_mutex);
+        for (const auto& characteristic : _characteristics) {
+            characteristic->reconcile_subscriptions(generation);
+        }
+    } catch (const std::exception& ex) {
+        SIMPLEBLE_LOG_WARN(fmt::format("Failed to reconcile subscriptions for Windows local service {}: {}", _uuid,
+                                       ex.what()));
+    } catch (...) {
+        SIMPLEBLE_LOG_WARN(
+            fmt::format("Failed to reconcile subscriptions for Windows local service {}", _uuid));
+    }
+}
+
+void ServiceWindows::enable_subscription_callbacks(uint64_t generation) {
+    if (_current_generation() != generation) {
+        return;
+    }
+    std::vector<std::shared_ptr<CharacteristicWindows>> characteristics;
+    {
+        std::scoped_lock lock(_mutex);
+        characteristics = _characteristics;
+    }
+    for (const auto& characteristic : characteristics) {
+        characteristic->enable_subscription_callbacks(generation);
+    }
+}
+
+bool ServiceWindows::is_advertising() const {
+    std::scoped_lock lock(_advertisement_mutex);
+    return _advertisement_status == GattServiceProviderAdvertisementStatus::Started ||
+           _advertisement_status == GattServiceProviderAdvertisementStatus::StartedWithoutAllAdvertisementData;
+}
+
+uint64_t ServiceWindows::_current_generation() {
+    const uint64_t generation = _active_generation.load();
+    if (generation == 0 || !_activity_observer || _activity_observer() != generation) {
+        return 0;
+    }
+    return generation;
+}
+
+}  // namespace SimpleBLE::Local

--- a/simpleble/src/backends/windows/LocalServiceWindows.h
+++ b/simpleble/src/backends/windows/LocalServiceWindows.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <vector>
+
+#include "../common/LocalServiceBase.h"
+#include "winrt/Windows.Devices.Bluetooth.GenericAttributeProfile.h"
+
+namespace SimpleBLE::Local {
+
+class CharacteristicWindows;
+
+class ServiceWindows : public ServiceBase, public std::enable_shared_from_this<ServiceWindows> {
+  public:
+    using GattSession = winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattSession;
+    using SessionObserver = std::function<void(const GattSession&, uint64_t expected_generation)>;
+    using ActivityObserver = std::function<uint64_t()>;
+    using CallbackObserver = std::function<bool(uint64_t)>;
+
+    ServiceWindows(BluetoothUUID uuid, SessionObserver session_observer, ActivityObserver activity_observer,
+                   CallbackObserver callback_observer);
+    ~ServiceWindows() override;
+
+    void initialize_handlers();
+
+    BluetoothUUID uuid() override;
+
+    std::shared_ptr<CharacteristicBase> add_characteristic(BluetoothUUID uuid,
+                                                           std::set<CharacteristicCapability> capabilities) override;
+    std::vector<std::shared_ptr<CharacteristicBase>> characteristics() override;
+
+    void freeze();
+    void unfreeze();
+    void activate(uint64_t generation);
+    void deactivate() noexcept;
+    void start_advertising();
+    void wait_until_advertising();
+    void stop_advertising();
+    void reset_subscriptions();
+    void reconcile_subscriptions(uint64_t generation) noexcept;
+    void enable_subscription_callbacks(uint64_t generation);
+    bool is_advertising() const;
+
+  private:
+    winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattServiceProvider _provider{nullptr};
+    BluetoothUUID _uuid;
+    SessionObserver _session_observer;
+    ActivityObserver _activity_observer;
+    CallbackObserver _callback_observer;
+    std::atomic_uint64_t _active_generation{0};
+    std::vector<std::shared_ptr<CharacteristicWindows>> _characteristics;
+    mutable std::mutex _mutex;
+    bool _frozen{false};
+
+    winrt::event_token _advertisement_status_changed_token{};
+    winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattServiceProviderAdvertisementStatus
+        _advertisement_status{winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::
+                                  GattServiceProviderAdvertisementStatus::Created};
+    winrt::Windows::Devices::Bluetooth::BluetoothError _advertisement_error{
+        winrt::Windows::Devices::Bluetooth::BluetoothError::Success};
+    bool _advertising_requested{false};
+    mutable std::mutex _advertisement_mutex;
+    std::condition_variable _advertisement_cv;
+
+    uint64_t _current_generation();
+};
+
+}  // namespace SimpleBLE::Local

--- a/simpleble/src/backends/windows/LocalServiceWindows.h
+++ b/simpleble/src/backends/windows/LocalServiceWindows.h
@@ -21,10 +21,8 @@ class ServiceWindows : public ServiceBase, public std::enable_shared_from_this<S
     using GattSession = winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattSession;
     using SessionObserver = std::function<void(const GattSession&, uint64_t expected_generation)>;
     using ActivityObserver = std::function<uint64_t()>;
-    using CallbackObserver = std::function<bool(uint64_t)>;
 
-    ServiceWindows(BluetoothUUID uuid, SessionObserver session_observer, ActivityObserver activity_observer,
-                   CallbackObserver callback_observer);
+    ServiceWindows(BluetoothUUID uuid, SessionObserver session_observer, ActivityObserver activity_observer);
     ~ServiceWindows() override;
 
     BluetoothUUID uuid() override;
@@ -41,8 +39,6 @@ class ServiceWindows : public ServiceBase, public std::enable_shared_from_this<S
     void wait_until_advertising(uint64_t generation);
     void stop_advertising();
     void reset_subscriptions();
-    void reconcile_subscriptions(uint64_t generation) noexcept;
-    void enable_subscription_callbacks(uint64_t generation);
     bool is_advertising() const;
 
   private:
@@ -50,7 +46,6 @@ class ServiceWindows : public ServiceBase, public std::enable_shared_from_this<S
     BluetoothUUID _uuid;
     SessionObserver _session_observer;
     ActivityObserver _activity_observer;
-    CallbackObserver _callback_observer;
     std::atomic_uint64_t _active_generation{0};
     std::vector<std::shared_ptr<CharacteristicWindows>> _characteristics;
     mutable std::mutex _mutex;

--- a/simpleble/src/backends/windows/LocalServiceWindows.h
+++ b/simpleble/src/backends/windows/LocalServiceWindows.h
@@ -19,7 +19,6 @@ class ServiceWindows : public ServiceBase, public std::enable_shared_from_this<S
   public:
     using GattSession = winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattSession;
     using SessionObserver = std::function<void(const GattSession&)>;
-    using ActivityObserver = std::function<bool()>;
 
     explicit ServiceWindows(BluetoothUUID uuid);
     ~ServiceWindows() override;
@@ -32,7 +31,7 @@ class ServiceWindows : public ServiceBase, public std::enable_shared_from_this<S
 
     void freeze();
     void unfreeze();
-    void create_native(SessionObserver session_observer, ActivityObserver activity_observer);
+    void create_native(SessionObserver session_observer, std::shared_ptr<std::atomic_bool> active);
     void destroy_native() noexcept;
     void start_advertising();
     void wait_until_advertising();
@@ -46,7 +45,6 @@ class ServiceWindows : public ServiceBase, public std::enable_shared_from_this<S
 
     struct NativeState {
         GattServiceProvider provider{nullptr};
-        ActivityObserver activity_observer;
         winrt::event_token advertisement_status_changed_token{};
         AdvertisementStatus advertisement_status{AdvertisementStatus::Created};
         winrt::Windows::Devices::Bluetooth::BluetoothError advertisement_error{
@@ -54,8 +52,6 @@ class ServiceWindows : public ServiceBase, public std::enable_shared_from_this<S
         bool advertising_requested{false};
         mutable std::mutex advertisement_mutex;
         std::condition_variable advertisement_cv;
-
-        bool active() const { return activity_observer && activity_observer(); }
     };
 
     BluetoothUUID _uuid;
@@ -64,7 +60,7 @@ class ServiceWindows : public ServiceBase, public std::enable_shared_from_this<S
     mutable std::mutex _mutex;
     bool _frozen{false};
 
-    std::shared_ptr<NativeState> _native_snapshot() const;
+    std::shared_ptr<NativeState> _native_state() const;
     static void _remove_advertisement_handler(const std::shared_ptr<NativeState>& native) noexcept;
 };
 

--- a/simpleble/src/backends/windows/LocalServiceWindows.h
+++ b/simpleble/src/backends/windows/LocalServiceWindows.h
@@ -27,8 +27,6 @@ class ServiceWindows : public ServiceBase, public std::enable_shared_from_this<S
                    CallbackObserver callback_observer);
     ~ServiceWindows() override;
 
-    void initialize_handlers();
-
     BluetoothUUID uuid() override;
 
     std::shared_ptr<CharacteristicBase> add_characteristic(BluetoothUUID uuid,
@@ -39,8 +37,8 @@ class ServiceWindows : public ServiceBase, public std::enable_shared_from_this<S
     void unfreeze();
     void activate(uint64_t generation);
     void deactivate() noexcept;
-    void start_advertising();
-    void wait_until_advertising();
+    void start_advertising(uint64_t generation);
+    void wait_until_advertising(uint64_t generation);
     void stop_advertising();
     void reset_subscriptions();
     void reconcile_subscriptions(uint64_t generation) noexcept;
@@ -64,11 +62,15 @@ class ServiceWindows : public ServiceBase, public std::enable_shared_from_this<S
                                   GattServiceProviderAdvertisementStatus::Created};
     winrt::Windows::Devices::Bluetooth::BluetoothError _advertisement_error{
         winrt::Windows::Devices::Bluetooth::BluetoothError::Success};
+    uint64_t _advertising_generation{0};
+    uint64_t _advertisement_status_generation{0};
     bool _advertising_requested{false};
     mutable std::mutex _advertisement_mutex;
     std::condition_variable _advertisement_cv;
 
     uint64_t _current_generation();
+    void _install_advertisement_handler(uint64_t generation);
+    void _remove_advertisement_handler() noexcept;
 };
 
 }  // namespace SimpleBLE::Local

--- a/simpleble/src/backends/windows/LocalServiceWindows.h
+++ b/simpleble/src/backends/windows/LocalServiceWindows.h
@@ -2,7 +2,6 @@
 
 #include <atomic>
 #include <condition_variable>
-#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -19,10 +18,10 @@ class CharacteristicWindows;
 class ServiceWindows : public ServiceBase, public std::enable_shared_from_this<ServiceWindows> {
   public:
     using GattSession = winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattSession;
-    using SessionObserver = std::function<void(const GattSession&, uint64_t expected_generation)>;
-    using ActivityObserver = std::function<uint64_t()>;
+    using SessionObserver = std::function<void(const GattSession&)>;
+    using ActivityObserver = std::function<bool()>;
 
-    ServiceWindows(BluetoothUUID uuid, SessionObserver session_observer, ActivityObserver activity_observer);
+    explicit ServiceWindows(BluetoothUUID uuid);
     ~ServiceWindows() override;
 
     BluetoothUUID uuid() override;
@@ -33,39 +32,40 @@ class ServiceWindows : public ServiceBase, public std::enable_shared_from_this<S
 
     void freeze();
     void unfreeze();
-    void activate(uint64_t generation);
-    void deactivate() noexcept;
-    void start_advertising(uint64_t generation);
-    void wait_until_advertising(uint64_t generation);
+    void create_native(SessionObserver session_observer, ActivityObserver activity_observer);
+    void destroy_native() noexcept;
+    void start_advertising();
+    void wait_until_advertising();
     void stop_advertising();
-    void reset_subscriptions();
     bool is_advertising() const;
 
   private:
-    winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattServiceProvider _provider{nullptr};
+    using GattServiceProvider = winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattServiceProvider;
+    using AdvertisementStatus =
+        winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattServiceProviderAdvertisementStatus;
+
+    struct NativeState {
+        GattServiceProvider provider{nullptr};
+        ActivityObserver activity_observer;
+        winrt::event_token advertisement_status_changed_token{};
+        AdvertisementStatus advertisement_status{AdvertisementStatus::Created};
+        winrt::Windows::Devices::Bluetooth::BluetoothError advertisement_error{
+            winrt::Windows::Devices::Bluetooth::BluetoothError::Success};
+        bool advertising_requested{false};
+        mutable std::mutex advertisement_mutex;
+        std::condition_variable advertisement_cv;
+
+        bool active() const { return activity_observer && activity_observer(); }
+    };
+
     BluetoothUUID _uuid;
-    SessionObserver _session_observer;
-    ActivityObserver _activity_observer;
-    std::atomic_uint64_t _active_generation{0};
     std::vector<std::shared_ptr<CharacteristicWindows>> _characteristics;
+    std::shared_ptr<NativeState> _native;
     mutable std::mutex _mutex;
     bool _frozen{false};
 
-    winrt::event_token _advertisement_status_changed_token{};
-    winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattServiceProviderAdvertisementStatus
-        _advertisement_status{winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::
-                                  GattServiceProviderAdvertisementStatus::Created};
-    winrt::Windows::Devices::Bluetooth::BluetoothError _advertisement_error{
-        winrt::Windows::Devices::Bluetooth::BluetoothError::Success};
-    uint64_t _advertising_generation{0};
-    uint64_t _advertisement_status_generation{0};
-    bool _advertising_requested{false};
-    mutable std::mutex _advertisement_mutex;
-    std::condition_variable _advertisement_cv;
-
-    uint64_t _current_generation();
-    void _install_advertisement_handler(uint64_t generation);
-    void _remove_advertisement_handler() noexcept;
+    std::shared_ptr<NativeState> _native_snapshot() const;
+    static void _remove_advertisement_handler(const std::shared_ptr<NativeState>& native) noexcept;
 };
 
 }  // namespace SimpleBLE::Local

--- a/simpleble/src/backends/windows/MtaManager.cpp
+++ b/simpleble/src/backends/windows/MtaManager.cpp
@@ -1,5 +1,7 @@
 #include "MtaManager.h"
 
+#include <windows.h>
+
 namespace SimpleBLE {
 namespace WinRT {
 
@@ -8,6 +10,11 @@ MtaManager::MtaManager() {
 }
 
 MtaManager::~MtaManager() {
+    // This destructor runs under the CRT exit lock. If COM unloads rometadata.dll
+    // while the MTA thread exits, that DLL's teardown can wait for the same lock
+    // and deadlock the join below. Keep an already-loaded copy until process exit.
+    HMODULE metadata_module = nullptr;
+    (void)GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_PIN, L"rometadata.dll", &metadata_module);
     stop();
     if (mta_thread_.joinable()) {
         mta_thread_.join();


### PR DESCRIPTION
## Summary

Add a first-pass Windows implementation of the existing SimpleBLE Peripheral API using WinRT GATT service providers. This keeps the public API unchanged and brings Windows alongside the Linux and macOS peripheral backends.

## What changed

- Implement Windows local peripheral, service, and characteristic backends.
- Publish the complete configured GATT table as one lifecycle, while treating advertisement service UUIDs as payload preferences.
- Support read, write, notify, subscribe/unsubscribe, and client connection callbacks.
- Add generation-safe start/stop/restart behavior, failed-start rollback, partial-stop recovery, and detached-service isolation.
- Use lifetime-safe WinRT event handlers and serialize lifecycle/subscription callback delivery on Windows thread-pool threads.
- Guard the Windows peripheral capability API for older Windows versions.
- Package the new backend and update examples, platform notes, FAQ, and other peripheral documentation.

## Why

SimpleBLE exposed a cross-platform Peripheral API, but Windows had no backend. The main implementation challenge was that WinRT exposes one `GattServiceProvider` per service while SimpleBLE presents one peripheral lifecycle. The backend coordinates every provider so callers never silently receive a partial hosted GATT table.

## User impact

Windows applications can now use the existing Peripheral API without source-level API changes. Requested local names remain subject to Windows system Bluetooth naming, and adapter/driver resource limits are surfaced as start failures rather than partial success.

## Validation

- Rebased on current `main` and resolved documentation conflicts.
- Release SimpleBLE build passed.
- Windows peripheral example build passed.
- Built SimplePyBLE wheel: `simplepyble-1.1.1-cp311-cp311-win_amd64.whl`.
- Corrected Dongl firmware v4 hardware test passed:
  - advertise and connect
  - characteristic read and write
  - notification delivery
  - stop, add a characteristic to the existing service, restart, reconnect, and read/write the new characteristic
- Multi-provider WinRT resource failure was surfaced and rolled back without leaving a partial peripheral live.
- Adversarial concurrency/lifecycle review found no remaining actionable release blockers.
- `git diff --cached --check origin/main` passed before commit.
- Public API paths under `simpleble/include` and `simplepyble/src` were unchanged.

## Notes

- No production Dongl source was changed. The known intermittent Dongl descriptor-ordering issue needed test-only containment during hardware validation.
- SimpleBLE unit tests were unavailable locally because GTest is not installed.
- SimplePyBLE pytest was unavailable locally because pytest is not installed.